### PR TITLE
Set the permissions for maven-assembly-plugin output files and paths.

### DIFF
--- a/assembly/dist-assembly.xml
+++ b/assembly/dist-assembly.xml
@@ -16,6 +16,8 @@
         <fileSet>
       		<directory>${project.basedir}/../angel-ps/conf</directory>
       		<outputDirectory>conf</outputDirectory>
+          <fileMode>0644</fileMode>
+          <directoryMode>0755</directoryMode>
     	</fileSet>
         <fileSet>
             <directory>${project.basedir}/../spark-on-angel/mllib/target</directory>
@@ -45,10 +47,14 @@
     	<fileSet>
       		<directory>${project.basedir}/../angel-ps/bin</directory>
       		<outputDirectory>bin</outputDirectory>
+          <fileMode>0755</fileMode>
+          <directoryMode>0755</directoryMode>
     	</fileSet>
       <fileSet>
           <directory>${project.basedir}/../spark-on-angel/bin</directory>
           <outputDirectory>bin</outputDirectory>
+          <fileMode>0755</fileMode>
+          <directoryMode>0755</directoryMode>
       </fileSet>
     </fileSets>
 </assembly>


### PR DESCRIPTION
Current branch-1.0.0:

<img width="717" alt="angen-bin" src="https://user-images.githubusercontent.com/302879/27258774-0e7b97f2-5436-11e7-827b-87a2d2dd5cf2.png">
<img width="662" alt="angel_conf" src="https://user-images.githubusercontent.com/302879/27258773-0e7aab30-5436-11e7-8b16-18cc5a42b5c0.png">

This PR: 

<img width="1000" alt="angel_conf" src="https://user-images.githubusercontent.com/302879/27258854-02b2017a-5438-11e7-8500-63b246f292b8.png">
<img width="987" alt="angen-bin" src="https://user-images.githubusercontent.com/302879/27258853-02b0d3fe-5438-11e7-8d9c-c08e35c4e20b.png">

