### PR TITLE
[SONA] Make spark submit exit normally after job finished

### DIFF
--- a/angel-ps/core/src/main/java/com/tencent/angel/psagent/matrix/transport/MatrixTransportClient.java
+++ b/angel-ps/core/src/main/java/com/tencent/angel/psagent/matrix/transport/MatrixTransportClient.java
@@ -241,6 +241,7 @@ public class MatrixTransportClient implements MatrixTransportInterface {
       if (channelManager != null) {
         channelManager.clear();
       }
+      eventGroup.shutdownGracefully();
     }
   }
 

--- a/spark-on-angel/core/src/main/scala/com/tencent/angel/spark/PSContext.scala
+++ b/spark-on-angel/core/src/main/scala/com/tencent/angel/spark/PSContext.scala
@@ -60,6 +60,9 @@ abstract class PSContext {
     doDestroyVectorPool(pool)
   }
 
+  def stop(): Unit = {
+  }
+
   protected def doCreateModelPool(numDimensions: Int, capacity: Int): PSModelPool
   protected def doDestroyVectorPool(pool: PSModelPool): Unit
 
@@ -103,6 +106,7 @@ object PSContext {
     if (PSContext.isAngelMode(env.conf)) {
       AngelPSContext.stop()
     }
+    PSContext.context.stop()
     PSContext.context = null
   }
 

--- a/spark-on-angel/core/src/main/scala/com/tencent/angel/spark/context/AngelPSContext.scala
+++ b/spark-on-angel/core/src/main/scala/com/tencent/angel/spark/context/AngelPSContext.scala
@@ -128,6 +128,12 @@ private[spark] class AngelPSContext private (id: Int, angelCtx: AngelContext) ex
       tc.partitionId()
     }
   }
+
+  override def stop(): Unit = {
+    if (psAgent != null) {
+      psAgent.stop()
+    }
+  }
 }
 
 private[spark] object AngelPSContext {


### PR DESCRIPTION
SONA-example will not exit normally in yarn-client mode when job finished, because some threads related to PSAgent are left there.

[31757.txt](https://github.com/Tencent/angel/files/1104774/31757.txt)

```
"ps-location-getter" #1537 prio=5 os_prio=0 tid=0x00007f1ae000d000 nid=0x40c waiting on condition [0x00007f1c97ffe000]
   java.lang.Thread.State: TIMED_WAITING (parking)
	at sun.misc.Unsafe.park(Native Method)
	- parking to wait for  <0x000000077d7c69c8> (a java.util.concurrent.CountDownLatch$Sync)
	at java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:215)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.doAcquireSharedNanos(AbstractQueuedSynchronizer.java:1037)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.tryAcquireSharedNanos(AbstractQueuedSynchronizer.java:1328)
	at java.util.concurrent.CountDownLatch.await(CountDownLatch.java:277)
	at com.tencent.angel.ipc.CallFuture.get(CallFuture.java:124)
	at com.tencent.angel.ipc.NettyTransceiver.call(NettyTransceiver.java:462)
	at com.tencent.angel.ipc.ProtobufRpcEngine$Invoker.invoke(ProtobufRpcEngine.java:290)
	at com.sun.proxy.$Proxy22.getPSLocation(Unknown Source)
	at com.tencent.angel.psagent.client.MasterClient.getPSLocation(MasterClient.java:89)
	at com.tencent.angel.psagent.matrix.transport.MatrixTransportClient$3.run(MatrixTransportClient.java:1082)
```
See the full jstack in the attachments