### PR TITLE
Fix NullPointer Exceptions when using old mapper api

### DIFF
--- a/angel-ps/core/src/main/java/com/tencent/angel/conf/AngelConfiguration.java
+++ b/angel-ps/core/src/main/java/com/tencent/angel/conf/AngelConfiguration.java
@@ -28,7 +28,7 @@ import com.tencent.angel.worker.Worker;
 import com.tencent.angel.worker.task.BaseTask;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.mapred.lib.CombineTextInputFormat;
+import org.apache.hadoop.mapreduce.lib.input.CombineTextInputFormat
 
 import java.util.Map;
 import java.util.Properties;

--- a/angel-ps/core/src/main/java/com/tencent/angel/conf/AngelConfiguration.java
+++ b/angel-ps/core/src/main/java/com/tencent/angel/conf/AngelConfiguration.java
@@ -28,7 +28,7 @@ import com.tencent.angel.worker.Worker;
 import com.tencent.angel.worker.task.BaseTask;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.mapreduce.lib.input.CombineTextInputFormat
+import org.apache.hadoop.mapreduce.lib.input.CombineTextInputFormat;
 
 import java.util.Map;
 import java.util.Properties;

--- a/angel-ps/core/src/main/java/com/tencent/angel/conf/AngelConfiguration.java
+++ b/angel-ps/core/src/main/java/com/tencent/angel/conf/AngelConfiguration.java
@@ -28,7 +28,7 @@ import com.tencent.angel.worker.Worker;
 import com.tencent.angel.worker.task.BaseTask;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.mapreduce.lib.input.CombineTextInputFormat;
+import org.apache.hadoop.mapred.lib.CombineTextInputFormat;
 
 import java.util.Map;
 import java.util.Properties;

--- a/angel-ps/core/src/main/java/com/tencent/angel/master/data/DataSpliter.java
+++ b/angel-ps/core/src/main/java/com/tencent/angel/master/data/DataSpliter.java
@@ -238,7 +238,7 @@ public class DataSpliter {
 
       SplitClassification splitClassification =
           new SplitClassification(splitList, null, locationList.toArray(new String[locationList
-              .size()]), true);
+              .size()]), useNewAPI);
       splitClassifications.put(i, splitClassification);
     }
   }

--- a/angel-ps/core/src/main/java/com/tencent/angel/worker/storage/DFSStorageOldAPI.java
+++ b/angel-ps/core/src/main/java/com/tencent/angel/worker/storage/DFSStorageOldAPI.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.RecordReader;
+import org.apache.hadoop.mapred.Reporter;
 import org.apache.hadoop.util.ReflectionUtils;
 
 import java.io.IOException;
@@ -60,8 +61,7 @@ public class DFSStorageOldAPI<KEY, VALUE> {
               new JobConf(conf));
 
       org.apache.hadoop.mapred.RecordReader<KEY, VALUE> recordReader =
-          inputFormat.getRecordReader(split, new JobConf(conf), null);
-
+          inputFormat.getRecordReader(split, new JobConf(conf), Reporter.NULL);
       setReader(new DFSReaderOldAPI(recordReader));
     } catch (Exception x) {
       LOG.error("init reader error ", x);


### PR DESCRIPTION
We encountered several null pointer exceptions when running LR_test using angel-submit.
Just fix these some problems.

```
2017-06-27 15:21:17,257 ERROR [main] com.tencent.angel.master.AngelApplicationMaster: Split failed, error: java.lang.ClassCastException: org.apache.hadoop.mapreduce.lib.input.CombineTextInputFormat cannot be cast to org.apache.hadoop.mapred.InputFormat
2017-06-27 15:21:17,257 FATAL [main] com.tencent.angel.master.AngelApplicationMaster: Error starting AppMaster
java.io.IOException: java.lang.ClassCastException: org.apache.hadoop.mapreduce.lib.input.CombineTextInputFormat cannot be cast to org.apache.hadoop.mapred.InputFormat
  at com.tencent.angel.master.AngelApplicationMaster.recoveryDataSplits(AngelApplicationMaster.java:817)
  at com.tencent.angel.master.AngelApplicationMaster.initAndStart(AngelApplicationMaster.java:693)   
  at com.tencent.angel.master.AngelApplicationMaster$1.run(AngelApplicationMaster.java:581)          
  at java.security.AccessController.doPrivileged(Native Method)                                      
  at javax.security.auth.Subject.doAs(Subject.java:422)                                              
  at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1885)            
  at com.tencent.angel.master.AngelApplicationMaster.main(AngelApplicationMaster.java:578)           
Caused by: java.lang.ClassCastException: org.apache.hadoop.mapreduce.lib.input.CombineTextInputFormat cannot be cast to org.apache.hadoop.mapred.InputFormat
  at com.tencent.angel.master.data.DataSpliter.generateSplitsUseOldAPI(DataSpliter.java:175)         
  at com.tencent.angel.master.data.DataSpliter.generateSplits(DataSpliter.java:94)                   
  at com.tencent.angel.master.AngelApplicationMaster.recoveryDataSplits(AngelApplicationMaster.java:813)
  ... 6 more
```
```
2017-06-27 15:53:07,921 ERROR [pool-8-thread-1] com.tencent.angel.worker.storage.DFSStorageOldAPI: init reader error 
java.lang.NullPointerException                                                                          
  at org.apache.hadoop.mapred.lib.CombineFileRecordReader.initNextRecordReader(CombineFileRecordReader.java:143)
  at org.apache.hadoop.mapred.lib.CombineFileRecordReader.<init>(CombineFileRecordReader.java:122)   
  at org.apache.hadoop.mapred.lib.CombineTextInputFormat.getRecordReader(CombineTextInputFormat.java:47)
  at com.tencent.angel.worker.storage.DFSStorageOldAPI.initReader(DFSStorageOldAPI.java:63)             
  at com.tencent.angel.worker.storage.DataBlockManager.getReader(DataBlockManager.java:96)              
  at com.tencent.angel.worker.task.TaskContext.getReader(TaskContext.java:106)                          
  at com.tencent.angel.ml.classification.lr.LRTrainTask.preProcess(LRTrainTask.scala:80)                
  at com.tencent.angel.worker.task.Task.runUser(Task.java:92)                                           
  at com.tencent.angel.worker.task.Task.run(Task.java:70)                                               
  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)                    
  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)                    
  at java.lang.Thread.run(Thread.java:745)
```