### PR TITLE
[SONA] Add current user's credential to PS application

### DIFF
--- a/angel-ps/core/src/main/java/com/tencent/angel/client/yarn/AngelYarnClient.java
+++ b/angel-ps/core/src/main/java/com/tencent/angel/client/yarn/AngelYarnClient.java
@@ -50,6 +50,7 @@ import org.apache.hadoop.mapreduce.filecache.ClientDistributedCacheManager;
 import org.apache.hadoop.mapreduce.filecache.DistributedCache;
 import org.apache.hadoop.mapreduce.security.TokenCache;
 import org.apache.hadoop.security.Credentials;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.yarn.api.ApplicationConstants;
 import org.apache.hadoop.yarn.api.ApplicationConstants.Environment;
 import org.apache.hadoop.yarn.api.protocolrecords.GetNewApplicationResponse;
@@ -139,6 +140,7 @@ public class AngelYarnClient extends AngelClient {
 
       setOutputDirectory();
 
+      credentials.addAll(UserGroupInformation.getCurrentUser().getCredentials());
       // Credentials credentials = new Credentials();
       TokenCache.obtainTokensForNamenodes(credentials, new Path[] {submitJobDir}, conf);
       checkParameters(conf);


### PR DESCRIPTION
AngelYarnClient will fail to obtain hdfs token when running SONA-example in yarn-cluster mode.
Add current user's credential to credentials in AngelYarnClient to fix this problem.

```
2017-06-27,19:03:33,731 INFO org.apache.spark.deploy.yarn.ApplicationMaster: Unregistering ApplicationMaster with FAILED (diag message: User class threw exception: org.apache.spark.SparkException: PSContext init failed!
	at com.tencent.angel.spark.PSContext$.getOrCreate(PSContext.scala:92)
	at com.tencent.angel.spark.PSContext$.getOrCreate(PSContext.scala:79)
	at com.tencent.angel.spark.examples.ml.BreezeSGD$$anonfun$main$1.apply(BreezeSGD.scala:42)
	at com.tencent.angel.spark.examples.ml.BreezeSGD$$anonfun$main$1.apply(BreezeSGD.scala:41)
	at com.tencent.angel.spark.examples.util.PSExamples$.runWithSparkContext(PSExamples.scala:50)
	at com.tencent.angel.spark.examples.ml.BreezeSGD$.main(BreezeSGD.scala:41)
	at com.tencent.angel.spark.examples.ml.BreezeSGD.main(BreezeSGD.scala)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.spark.deploy.yarn.ApplicationMaster$$anon$2.run(ApplicationMaster.scala:648)
Caused by: com.tencent.angel.exception.AngelException: org.apache.hadoop.ipc.RemoteException(java.io.IOException): Delegation Token can be issued only with kerberos or web authentication
	at org.apache.hadoop.hdfs.server.namenode.FSNamesystem.getDelegationToken(FSNamesystem.java:6512)
	at org.apache.hadoop.hdfs.server.namenode.NameNodeRpcServer.getDelegationToken(NameNodeRpcServer.java:560)
	at org.apache.hadoop.hdfs.protocolPB.ClientNamenodeProtocolServerSideTranslatorPB.getDelegationToken(ClientNamenodeProtocolServerSideTranslatorPB.java:939)
	at org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos$ClientNamenodeProtocol$2.callBlockingMethod(ClientNamenodeProtocolProtos.java)
	at org.apache.hadoop.ipc.ProtobufRpcEngine$Server$ProtoBufRpcInvoker.call(ProtobufRpcEngine.java:585)
	at org.apache.hadoop.ipc.RPC$Server.call(RPC.java:928)
	at org.apache.hadoop.ipc.Server$Handler$1.run(Server.java:2039)
	at org.apache.hadoop.ipc.Server$Handler$1.run(Server.java:2035)
	at java.security.AccessController.doPrivileged(Native Method)
	at javax.security.auth.Subject.doAs(Subject.java:396)
	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1806)
	at org.apache.hadoop.ipc.Server$Handler.run(Server.java:2033)

	at com.tencent.angel.client.yarn.AngelYarnClient.startPSServer(AngelYarnClient.java:179)
	at com.tencent.angel.client.AngelPSClient.startPS(AngelPSClient.java:99)
	at com.tencent.angel.spark.context.AngelPSContext$.submit(AngelPSContext.scala:250)
	at com.tencent.angel.spark.context.AngelPSContext$.apply(AngelPSContext.scala:152)
	at com.tencent.angel.spark.PSContext$.liftedTree1$1(PSContext.scala:124)
	at com.tencent.angel.spark.PSContext$.instance(PSContext.scala:122)
	at com.tencent.angel.spark.PSContext$.getOrCreate(PSContext.scala:91)
	... 11 more
Caused by: org.apache.hadoop.ipc.RemoteException(java.io.IOException): Delegation Token can be issued only with kerberos or web authentication
	at org.apache.hadoop.hdfs.server.namenode.FSNamesystem.getDelegationToken(FSNamesystem.java:6512)
	at org.apache.hadoop.hdfs.server.namenode.NameNodeRpcServer.getDelegationToken(NameNodeRpcServer.java:560)
	at org.apache.hadoop.hdfs.protocolPB.ClientNamenodeProtocolServerSideTranslatorPB.getDelegationToken(ClientNamenodeProtocolServerSideTranslatorPB.java:939)
	at org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos$ClientNamenodeProtocol$2.callBlockingMethod(ClientNamenodeProtocolProtos.java)
	at org.apache.hadoop.ipc.ProtobufRpcEngine$Server$ProtoBufRpcInvoker.call(ProtobufRpcEngine.java:585)
	at org.apache.hadoop.ipc.RPC$Server.call(RPC.java:928)
	at org.apache.hadoop.ipc.Server$Handler$1.run(Server.java:2039)
	at org.apache.hadoop.ipc.Server$Handler$1.run(Server.java:2035)
	at java.security.AccessController.doPrivileged(Native Method)
	at javax.security.auth.Subject.doAs(Subject.java:396)
	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1806)
	at org.apache.hadoop.ipc.Server$Handler.run(Server.java:2033)

	at org.apache.hadoop.ipc.Client.call(Client.java:1477)
	at org.apache.hadoop.ipc.Client.call(Client.java:1408)
	at org.apache.hadoop.ipc.ProtobufRpcEngine$Invoker.invoke(ProtobufRpcEngine.java:232)
	at com.sun.proxy.$Proxy9.getDelegationToken(Unknown Source)
	at org.apache.hadoop.hdfs.protocolPB.ClientNamenodeProtocolTranslatorPB.getDelegationToken(ClientNamenodeProtocolTranslatorPB.java:988)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.hadoop.io.retry.RetryInvocationHandler.invokeMethod(RetryInvocationHandler.java:187)
	at org.apache.hadoop.io.retry.RetryInvocationHandler.invoke(RetryInvocationHandler.java:102)
	at com.sun.proxy.$Proxy10.getDelegationToken(Unknown Source)
	at org.apache.hadoop.hdfs.DFSClient.getDelegationToken(DFSClient.java:1058)
	at org.apache.hadoop.hdfs.DistributedFileSystem.getDelegationToken(DistributedFileSystem.java:1433)
	at org.apache.hadoop.fs.FileSystem.collectDelegationTokens(FileSystem.java:529)
	at org.apache.hadoop.fs.FileSystem.addDelegationTokens(FileSystem.java:507)
	at org.apache.hadoop.hdfs.DistributedFileSystem.addDelegationTokens(DistributedFileSystem.java:2118)
	at org.apache.hadoop.mapreduce.security.TokenCache.obtainTokensForNamenodesInternal(TokenCache.java:140)
	at org.apache.hadoop.mapreduce.security.TokenCache.obtainTokensForNamenodesInternal(TokenCache.java:100)
	at org.apache.hadoop.mapreduce.security.TokenCache.obtainTokensForNamenodes(TokenCache.java:80)
	at com.tencent.angel.client.yarn.AngelYarnClient.startPSServer(AngelYarnClient.java:150)
	... 17 more
)
```