### PR TITLE
Fix token delegation problem in DataSpliter when using new mapper api

### DIFF
--- a/angel-ps/core/src/main/java/com/tencent/angel/master/data/DataSpliter.java
+++ b/angel-ps/core/src/main/java/com/tencent/angel/master/data/DataSpliter.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.mapred.*;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.ReflectionUtils;
 
 import java.io.IOException;
@@ -129,6 +130,7 @@ public class DataSpliter {
     JobID jobID = JobID.forName(jobIDStr);
     JobContext jobConf = new JobContextImpl(new JobConf(conf), jobID);
 
+    jobConf.getCredentials().addAll(UserGroupInformation.getCurrentUser().getCredentials());
     // Set split minsize and maxsize to expected split size. We need to get the total size of data
     // first, then divided by expected split number
     long totalInputFileSize = HdfsUtil.getInputFileTotalSize(jobConf);


### PR DESCRIPTION
HDFS token delegation in DataSpliter will be failed when using the new mapper api.

Add current user's credentials to job context to fix it.

```
2017-06-27 17:41:41,010 FATAL [main] com.tencent.angel.master.AngelApplicationMaster: Error starting AppMaster
java.io.IOException: org.apache.hadoop.ipc.RemoteException(java.io.IOException): Delegation Token can be issued only with kerberos or web authentication
  at org.apache.hadoop.hdfs.server.namenode.FSNamesystem.getDelegationToken(FSNamesystem.java:6512)  
  at org.apache.hadoop.hdfs.server.namenode.NameNodeRpcServer.getDelegationToken(NameNodeRpcServer.java:560)
  at org.apache.hadoop.hdfs.protocolPB.ClientNamenodeProtocolServerSideTranslatorPB.getDelegationToken(ClientNamenodeProtocolServerSideTranslatorPB.java:939)
  at org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos$ClientNamenodeProtocol$2.callBlockingMethod(ClientNamenodeProtocolProtos.java)
  at org.apache.hadoop.ipc.ProtobufRpcEngine$Server$ProtoBufRpcInvoker.call(ProtobufRpcEngine.java:585)
  at org.apache.hadoop.ipc.RPC$Server.call(RPC.java:928)                                             
  at org.apache.hadoop.ipc.Server$Handler$1.run(Server.java:2039)                                    
  at org.apache.hadoop.ipc.Server$Handler$1.run(Server.java:2035)                                    
  at java.security.AccessController.doPrivileged(Native Method)                                      
  at javax.security.auth.Subject.doAs(Subject.java:396)                                              
  at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1806)            
  at org.apache.hadoop.ipc.Server$Handler.run(Server.java:2033)                                      
                                                                                                     
  at com.tencent.angel.master.AngelApplicationMaster.recoveryDataSplits(AngelApplicationMaster.java:816)
  at com.tencent.angel.master.AngelApplicationMaster.initAndStart(AngelApplicationMaster.java:692)   
  at com.tencent.angel.master.AngelApplicationMaster$1.run(AngelApplicationMaster.java:580)          
  at java.security.AccessController.doPrivileged(Native Method)                                      
  at javax.security.auth.Subject.doAs(Subject.java:422)                                              
  at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1885)            
  at com.tencent.angel.master.AngelApplicationMaster.main(AngelApplicationMaster.java:577)           
Caused by: org.apache.hadoop.ipc.RemoteException(java.io.IOException): Delegation Token can be issued only with kerberos or web authentication
  at org.apache.hadoop.hdfs.server.namenode.FSNamesystem.getDelegationToken(FSNamesystem.java:6512)  
  at org.apache.hadoop.hdfs.server.namenode.NameNodeRpcServer.getDelegationToken(NameNodeRpcServer.java:560)
  at org.apache.hadoop.hdfs.protocolPB.ClientNamenodeProtocolServerSideTranslatorPB.getDelegationToken(ClientNamenodeProtocolServerSideTranslatorPB.java:939)
  at org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos$ClientNamenodeProtocol$2.callBlockingMethod(ClientNamenodeProtocolProtos.java)
  at org.apache.hadoop.ipc.ProtobufRpcEngine$Server$ProtoBufRpcInvoker.call(ProtobufRpcEngine.java:585)
  at org.apache.hadoop.ipc.RPC$Server.call(RPC.java:928)                                             
  at org.apache.hadoop.ipc.Server$Handler$1.run(Server.java:2039)                                    
  at org.apache.hadoop.ipc.Server$Handler$1.run(Server.java:2035)                                    
  at java.security.AccessController.doPrivileged(Native Method)                                      
  at javax.security.auth.Subject.doAs(Subject.java:396)                                              
  at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1806)            
  at org.apache.hadoop.ipc.Server$Handler.run(Server.java:2033)                                  
                                                                                                     
  at org.apache.hadoop.ipc.Client.call(Client.java:1477)                                             
  at org.apache.hadoop.ipc.Client.call(Client.java:1408)                                             
  at org.apache.hadoop.ipc.ProtobufRpcEngine$Invoker.invoke(ProtobufRpcEngine.java:232)              
  at com.sun.proxy.$Proxy9.getDelegationToken(Unknown Source)                                        
  at org.apache.hadoop.hdfs.protocolPB.ClientNamenodeProtocolTranslatorPB.getDelegationToken(ClientNamenodeProtocolTranslatorPB.java:988)
  at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)                                     
  at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)                   
  at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)           
  at java.lang.reflect.Method.invoke(Method.java:498)                                                
  at org.apache.hadoop.io.retry.RetryInvocationHandler.invokeMethod(RetryInvocationHandler.java:187) 
  at org.apache.hadoop.io.retry.RetryInvocationHandler.invoke(RetryInvocationHandler.java:102)       
  at com.sun.proxy.$Proxy10.getDelegationToken(Unknown Source)                                       
  at org.apache.hadoop.hdfs.DFSClient.getDelegationToken(DFSClient.java:1058)                        
  at org.apache.hadoop.hdfs.DistributedFileSystem.getDelegationToken(DistributedFileSystem.java:1433)
  at org.apache.hadoop.fs.FileSystem.collectDelegationTokens(FileSystem.java:529)                    
  at org.apache.hadoop.fs.FileSystem.addDelegationTokens(FileSystem.java:507)                        
  at org.apache.hadoop.hdfs.DistributedFileSystem.addDelegationTokens(DistributedFileSystem.java:2118)
  at org.apache.hadoop.mapreduce.security.TokenCache.obtainTokensForNamenodesInternal(TokenCache.java:140)
  at org.apache.hadoop.mapreduce.security.TokenCache.obtainTokensForNamenodesInternal(TokenCache.java:100)
  at org.apache.hadoop.mapreduce.security.TokenCache.obtainTokensForNamenodes(TokenCache.java:80)    
  at org.apache.hadoop.mapreduce.lib.input.FileInputFormat.listStatus(FileInputFormat.java:242)      
  at org.apache.hadoop.mapreduce.lib.input.CombineFileInputFormat.getSplits(CombineFileInputFormat.java:217)
  at com.tencent.angel.master.data.DataSpliter.generateSplitsUseNewAPI(DataSpliter.java:154)         
  at com.tencent.angel.master.data.DataSpliter.generateSplits(DataSpliter.java:110)                  
  at com.tencent.angel.master.AngelApplicationMaster.recoveryDataSplits(AngelApplicationMaster.java:812)
  ... 6 more
```