### PR TITLE
Using the username from UserGroupInformation instead of Environment.USER

### DIFF
--- a/angel-ps/core/src/main/java/com/tencent/angel/master/AngelApplicationMaster.java
+++ b/angel-ps/core/src/main/java/com/tencent/angel/master/AngelApplicationMaster.java
@@ -534,11 +534,14 @@ public class AngelApplicationMaster extends CompositeService {
       Configuration conf = new Configuration();
       conf.addResource(AngelConfiguration.ANGEL_JOB_CONF_FILE);
 
-      String jobUserName = System.getenv(ApplicationConstants.Environment.USER.name());
-      conf.set(AngelConfiguration.USER_NAME, jobUserName);
-      conf.setBoolean("fs.automatic.close", false);
 
+      conf.setBoolean("fs.automatic.close", false);
       UserGroupInformation.setConfiguration(conf);
+
+      UserGroupInformation appMasterUgi = UserGroupInformation.getCurrentUser();
+
+      String jobUserName = appMasterUgi.getUserName();
+      conf.set(AngelConfiguration.USER_NAME, jobUserName);
 
       // Security framework already loaded the tokens into current UGI, just use
       // them
@@ -548,11 +551,6 @@ public class AngelApplicationMaster extends CompositeService {
       for (Token<?> token : credentials.getAllTokens()) {
         LOG.info(token);
       }
-
-      UserGroupInformation appMasterUgi = UserGroupInformation
-        .createRemoteUser(jobUserName);
-      appMasterUgi.addCredentials(credentials);
-
       // Now remove the AM->RM token so tasks don't have it
       Iterator<Token<?>> iter = credentials.getAllTokens().iterator();
       while (iter.hasNext()) {

--- a/angel-ps/core/src/main/java/com/tencent/angel/ps/impl/ParameterServer.java
+++ b/angel-ps/core/src/main/java/com/tencent/angel/ps/impl/ParameterServer.java
@@ -187,7 +187,7 @@ public class ParameterServer {
     }
   }
 
-  public static void main(String[] argv)  {
+  public static void main(String[] argv) throws IOException {
     LOG.info("Starting Parameter Server");
     int serverIndex = Integer.valueOf(System.getenv(AngelEnvironment.PARAMETERSERVER_ID.name()));
     String appMasterHost = System.getenv(AngelEnvironment.LISTEN_ADDR.name());
@@ -198,9 +198,9 @@ public class ParameterServer {
     Configuration conf = new Configuration();
     conf.addResource(AngelConfiguration.ANGEL_JOB_CONF_FILE);
 
-    String user = System.getenv(ApplicationConstants.Environment.USER.name());
     UserGroupInformation.setConfiguration(conf);
-    
+    UserGroupInformation psUGI = UserGroupInformation.getCurrentUser();
+
     String runningMode = conf.get(AngelConfiguration.ANGEL_RUNNING_MODE, 
         AngelConfiguration.DEFAULT_ANGEL_RUNNING_MODE);   
     if(runningMode.equals(RunningMode.ANGEL_PS_WORKER.toString())){
@@ -215,13 +215,6 @@ public class ParameterServer {
     PSContext.get().setPs(psServer);
 
     try{
-      Credentials credentials =
-        UserGroupInformation.getCurrentUser().getCredentials();
-      UserGroupInformation psUGI = UserGroupInformation.createRemoteUser(System
-        .getenv(ApplicationConstants.Environment.USER.toString()));
-      // Add tokens to new user so that it may execute its task correctly.
-      psUGI.addCredentials(credentials);
-
       psUGI.doAs(new PrivilegedExceptionAction<Object>() {
         @Override
         public Object run() throws Exception {

--- a/angel-ps/core/src/main/java/com/tencent/angel/psagent/PSAgent.java
+++ b/angel-ps/core/src/main/java/com/tencent/angel/psagent/PSAgent.java
@@ -52,6 +52,7 @@ import com.tencent.angel.protobuf.generated.PSAgentMasterServiceProtos.PSAgentRe
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.yarn.api.ApplicationConstants.Environment;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
@@ -695,7 +696,7 @@ public class PSAgent {
     return matrixTransClient;
   }
 
-  public static void main(String[] args) {
+  public static void main(String[] args) throws IOException {
     // get configuration from config file
     Configuration conf = new Configuration();
     conf.addResource(AngelConfiguration.ANGEL_JOB_CONF_FILE);
@@ -704,7 +705,9 @@ public class PSAgent {
     ContainerId containerId = ConverterUtils.toContainerId(containerIdStr);
     ApplicationAttemptId applicationAttemptId = containerId.getApplicationAttemptId();
     ApplicationId appId = applicationAttemptId.getApplicationId();
-    String user = System.getenv(Environment.USER.name());
+
+    UserGroupInformation.setConfiguration(conf);
+    String user = UserGroupInformation.getCurrentUser().getUserName();
 
     // set localDir with enviroment set by nm.
     String[] localSysDirs =

--- a/angel-ps/core/src/main/java/com/tencent/angel/worker/Worker.java
+++ b/angel-ps/core/src/main/java/com/tencent/angel/worker/Worker.java
@@ -179,7 +179,7 @@ public class Worker implements Executor {
     }
   }
 
-  public static void main(String[] args) {
+  public static void main(String[] args) throws IOException {
     // get configuration from config file
     Configuration conf = new Configuration();
     conf.addResource(AngelConfiguration.ANGEL_JOB_CONF_FILE);
@@ -188,8 +188,8 @@ public class Worker implements Executor {
     ContainerId containerId = ConverterUtils.toContainerId(containerIdStr);
     ApplicationAttemptId applicationAttemptId = containerId.getApplicationAttemptId();
     ApplicationId appId = applicationAttemptId.getApplicationId();
-    String user = System.getenv(Environment.USER.name());
     UserGroupInformation.setConfiguration(conf);
+    String user = UserGroupInformation.getCurrentUser().getUserName();
 
     // set localDir with enviroment set by nm.
     String[] localSysDirs =
@@ -228,12 +228,7 @@ public class Worker implements Executor {
         masterLocation, Integer.valueOf(startClock), false);
 
     try {
-      Credentials credentials =
-        UserGroupInformation.getCurrentUser().getCredentials();
-      UserGroupInformation workerUGI = UserGroupInformation.createRemoteUser(System
-        .getenv(ApplicationConstants.Environment.USER.toString()));
-      // Add tokens to new user so that it may execute its task correctly.
-      workerUGI.addCredentials(credentials);
+      UserGroupInformation workerUGI = UserGroupInformation.getCurrentUser();
 
       workerUGI.doAs(new PrivilegedExceptionAction<Object>() {
         @Override


### PR DESCRIPTION
In angel, it gets the user name from env. But in our Hadoop env, this user name not same as the job submitter's name. So I encounterd following exception when submitting angel jobs.

In secure Hadoop,  I think we can use the user name from the UserGroupInformation.

I am not sure if this is a common issue. Maybe there are some other reasons.
Please point it out from me. Thanks~

```
2017-06-20 15:59:29,114 FATAL [AsyncDispatcher event handler] org.apache.hadoop.yarn.event.AsyncDispatcher: Error in dispatcher thread
org.apache.hadoop.yarn.exceptions.YarnRuntimeException: java.io.FileNotFoundException: File does not exist: /yarn/staging/work/.staging/application_1497567366016_167790/job.xml
	at com.tencent.angel.master.yarn.util.ContainerContextUtils.createCommonContainerLaunchContext(ContainerContextUtils.java:195)
	at com.tencent.angel.master.yarn.util.ContainerContextUtils.createContainerLaunchContext(ContainerContextUtils.java:220)
	at com.tencent.angel.master.ps.attempt.PSAttempt$ContainerAssignedTransition.transition(PSAttempt.java:323)
	at com.tencent.angel.master.ps.attempt.PSAttempt$ContainerAssignedTransition.transition(PSAttempt.java:305)
	at org.apache.hadoop.yarn.state.StateMachineFactory$SingleInternalArc.doTransition(StateMachineFactory.java:362)
	at org.apache.hadoop.yarn.state.StateMachineFactory.doTransition(StateMachineFactory.java:302)
	at org.apache.hadoop.yarn.state.StateMachineFactory.access$300(StateMachineFactory.java:46)
	at org.apache.hadoop.yarn.state.StateMachineFactory$InternalStateMachine.doTransition(StateMachineFactory.java:448)
	at com.tencent.angel.master.ps.attempt.PSAttempt.handle(PSAttempt.java:254)
	at com.tencent.angel.master.AngelApplicationMaster$PSAttemptEventDispatcher.handle(AngelApplicationMaster.java:865)
	at com.tencent.angel.master.AngelApplicationMaster$PSAttemptEventDispatcher.handle(AngelApplicationMaster.java:859)
	at org.apache.hadoop.yarn.event.AsyncDispatcher.dispatch(AsyncDispatcher.java:176)
	at org.apache.hadoop.yarn.event.AsyncDispatcher$1.run(AsyncDispatcher.java:108)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.io.FileNotFoundException: File does not exist: /yarn/staging/work/.staging/application_1497567366016_167790/job.xml
	at org.apache.hadoop.hdfs.DistributedFileSystem$20.doCall(DistributedFileSystem.java:1199)
	at org.apache.hadoop.hdfs.DistributedFileSystem$20.doCall(DistributedFileSystem.java:1191)
	at org.apache.hadoop.fs.FileSystemLinkResolver.resolve(FileSystemLinkResolver.java:81)
	at org.apache.hadoop.hdfs.DistributedFileSystem.getFileStatus(DistributedFileSystem.java:1207)
	at com.tencent.angel.master.yarn.util.ContainerContextUtils.createLocalResource(ContainerContextUtils.java:255)
	at com.tencent.angel.master.yarn.util.Contain
```