### PR TITLE
Should put angel lib dependencies in the beginning of classpath

### DIFF
--- a/angel-ps/bin/angel-submit
+++ b/angel-ps/bin/angel-submit
@@ -22,7 +22,7 @@ HADOOP_LIBEXEC_DIR=${HADOOP_LIBEXEC_DIR:-$DEFAULT_LIBEXEC_DIR}
 for f in "$lib"/*.jar; do
     echo $f
     if [ "$CLASSPATH" ]; then
-        export CLASSPATH=$CLASSPATH:$f
+        export CLASSPATH=$f:$CLASSPATH
     else
         export CLASSPATH=$f
     fi


### PR DESCRIPTION
Angel should load dependencies from its lib folder first. Hadoop classpath may contain lots of java libs that have different versions with Angel's. The protobuf-2.5.0 is an example though you recommend in the document we'd better keep using protobuf-2.5.0 instead of a higher version（Actually, for using a higher version, we just need to upload the 'higher version protobuf jar' by setting angel.job.jar parameter'）. There still are lots of chances more lib conflicts will be introduced as Angel grows up.