### PR TITLE
BUG: url starts with null when hdfs prefix is missing

### DIFF
--- a/angel-ps/core/src/main/java/com/tencent/angel/utils/HdfsUtil.java
+++ b/angel-ps/core/src/main/java/com/tencent/angel/utils/HdfsUtil.java
@@ -373,7 +373,8 @@ public class HdfsUtil {
 
   public static Path generateTmpDirectory(Configuration conf, String appId, Path outputPath) {
     URI uri = outputPath.toUri();
-    String path = uri.getScheme() + "://" + (uri.getHost() != null ? uri.getHost() : "")
+    String path = (uri.getScheme() != null ? uri.getScheme() : "hdfs") + "://"
+        + (uri.getHost() != null ? uri.getHost() : "")
         + (uri.getPort() > 0 ? (":" + uri.getPort()) : "");
     String user = conf.get(AngelConfiguration.USER_NAME, "");
     String tmpDir = conf.get(AngelConfiguration.ANGEL_JOB_TMP_OUTPUT_DIRECTORY, "/tmp/" + user);


### PR DESCRIPTION
The pr is aim at fixing #130 

Replace missing schema with hdfs.

+ [x] submit an LR example on YARN without hdfs prefix, and take a test.
+ [ ] As the pr is quite trivial and simple, is an unit test needed?

