### PR TITLE
ENH: add y-intercept for logistic regression

### DIFF
--- a/angel-ps/mllib/src/main/java/com/tencent/angel/ml/classification/lr/LRLearner.scala
+++ b/angel-ps/mllib/src/main/java/com/tencent/angel/ml/classification/lr/LRLearner.scala
@@ -69,7 +69,7 @@ class LRLearner(override val ctx: TaskContext) extends MLLearner(ctx) {
 
     // Apply mini-batch gradient descent
     val startBatch = System.currentTimeMillis()
-    val batchGD = GradientDescent.miniBatchGD(trainData, lrModel.weight, None,
+    val batchGD = GradientDescent.miniBatchGD(trainData, lrModel.weight, lrModel.intercept,
                                               lr, logLoss, batchSize, batchNum)
     val loss = batchGD._1
     val localWeight = batchGD._2

--- a/angel-ps/mllib/src/main/java/com/tencent/angel/ml/classification/lr/LRLearner.scala
+++ b/angel-ps/mllib/src/main/java/com/tencent/angel/ml/classification/lr/LRLearner.scala
@@ -69,8 +69,8 @@ class LRLearner(override val ctx: TaskContext) extends MLLearner(ctx) {
 
     // Apply mini-batch gradient descent
     val startBatch = System.currentTimeMillis()
-    val batchGD = GradientDescent.miniBatchGD(trainData, lrModel.weight, lr, logLoss,
-      batchSize, batchNum)
+    val batchGD = GradientDescent.miniBatchGD(trainData, lrModel.weight, None,
+                                              lr, logLoss, batchSize, batchNum)
     val loss = batchGD._1
     val localWeight = batchGD._2
     val batchCost = System.currentTimeMillis() - startBatch

--- a/angel-ps/mllib/src/main/java/com/tencent/angel/ml/classification/lr/LRModel.scala
+++ b/angel-ps/mllib/src/main/java/com/tencent/angel/ml/classification/lr/LRModel.scala
@@ -65,9 +65,11 @@ class LRModel(_ctx: TaskContext, conf: Configuration) extends MLModel(_ctx) {
   // The feature weight vector, stored on PS
   val weight = PSModel[DenseDoubleVector](LR_WEIGHT_MAT, 1, feaNum)
   weight.setAverage(true)
+
+  private val intercept_ = PSModel[DenseDoubleVector](LR_INTERCEPT, 1, 1)
   val intercept =
     if (conf.getBoolean(MLConf.LR_USE_INTERCEPT, MLConf.DEFAULT_LR_USE_INTERCEPT)) {
-      Some(PSModel[DenseDoubleVector](LR_INTERCEPT, 1, 1))
+      Some(intercept_)
     } else {
       None
     }
@@ -81,6 +83,7 @@ class LRModel(_ctx: TaskContext, conf: Configuration) extends MLModel(_ctx) {
   setLoadPath(conf)
 
   addPSModel(LR_WEIGHT_MAT, weight)
+  addPSModel(LR_INTERCEPT, intercept_)
   addPSModel(LR_LOSS_MAT, loss)
 
   override

--- a/angel-ps/mllib/src/main/java/com/tencent/angel/ml/classification/lr/LRModel.scala
+++ b/angel-ps/mllib/src/main/java/com/tencent/angel/ml/classification/lr/LRModel.scala
@@ -67,6 +67,7 @@ class LRModel(_ctx: TaskContext, conf: Configuration) extends MLModel(_ctx) {
   weight.setAverage(true)
 
   private val intercept_ = PSModel[DenseDoubleVector](LR_INTERCEPT, 1, 1)
+  intercept_.setAverage(true)
   val intercept =
     if (conf.getBoolean(MLConf.LR_USE_INTERCEPT, MLConf.DEFAULT_LR_USE_INTERCEPT)) {
       Some(intercept_)

--- a/angel-ps/mllib/src/main/java/com/tencent/angel/ml/classification/lr/LRModel.scala
+++ b/angel-ps/mllib/src/main/java/com/tencent/angel/ml/classification/lr/LRModel.scala
@@ -53,6 +53,7 @@ class LRModel(_ctx: TaskContext, conf: Configuration) extends MLModel(_ctx) {
   private val LOG = LogFactory.getLog(classOf[LRModel])
 
   val LR_WEIGHT_MAT = "lr_weight"
+  val LR_INTERCEPT = "lr_intercept"
   val LR_LOSS_MAT = "lr_loss"
 
   def this(conf: Configuration) = {
@@ -64,6 +65,12 @@ class LRModel(_ctx: TaskContext, conf: Configuration) extends MLModel(_ctx) {
   // The feature weight vector, stored on PS
   val weight = PSModel[DenseDoubleVector](LR_WEIGHT_MAT, 1, feaNum)
   weight.setAverage(true)
+  val intercept =
+    if (conf.getBoolean(MLConf.LR_USE_INTERCEPT, MLConf.DEFAULT_LR_USE_INTERCEPT)) {
+      Some(PSModel[DenseDoubleVector](LR_INTERCEPT, 1, 1))
+    } else {
+      None
+    }
 
   // Iteration number
   val epochNum = conf.getInt(MLConf.ML_EPOCH_NUM, MLConf.DEFAULT_ML_EPOCH_NUM)

--- a/angel-ps/mllib/src/main/java/com/tencent/angel/ml/classification/lr/LRModel.scala
+++ b/angel-ps/mllib/src/main/java/com/tencent/angel/ml/classification/lr/LRModel.scala
@@ -108,6 +108,7 @@ class LRModel(_ctx: TaskContext, conf: Configuration) extends MLModel(_ctx) {
   def predict(dataSet: DataBlock[LabeledData]): DataBlock[PredictResult] = {
     val start = System.currentTimeMillis()
     val wVector = weight.getRow(0)
+    val b = intercept.map(_.getRow(0).get(0)).getOrElse(0.0)
     val cost = System.currentTimeMillis() - start
     LOG.info(s"pull LR Model from PS cost $cost ms." )
 
@@ -117,7 +118,7 @@ class LRModel(_ctx: TaskContext, conf: Configuration) extends MLModel(_ctx) {
     for (idx: Int <- 0 until dataSet.getTotalElemNum) {
       val instance = dataSet.read
       val id = instance.getY
-      val dot = wVector.dot(instance.getX)
+      val dot = wVector.dot(instance.getX) + b
       val sig = MathUtils.sigmoid(dot)
       predict.put(new lrPredictResult(id, dot, sig))
     }

--- a/angel-ps/mllib/src/main/java/com/tencent/angel/ml/classification/svm/SVMLearner.scala
+++ b/angel-ps/mllib/src/main/java/com/tencent/angel/ml/classification/svm/SVMLearner.scala
@@ -69,7 +69,8 @@ class SVMLearner(override val ctx: TaskContext) extends MLLearner(ctx) {
 
     val startGD = System.currentTimeMillis()
     // Run mini-batch gradient descent.
-    val ret = GradientDescent.miniBatchGD(trainData, weight, learnRate, hingeLoss, batchSize, batchNum)
+    val ret = GradientDescent.miniBatchGD(trainData, weight, None,
+                                          learnRate, hingeLoss, batchSize, batchNum)
     val loss = ret._1
     val localW = ret._2
 

--- a/angel-ps/mllib/src/main/java/com/tencent/angel/ml/conf/MLConf.scala
+++ b/angel-ps/mllib/src/main/java/com/tencent/angel/ml/conf/MLConf.scala
@@ -63,6 +63,10 @@ object MLConf {
   val ML_LEARN_DECAY = "ml.learn.decay"
   val DEFAULT_ML_LEARN_DECAY = 0.5
 
+  // Logistic Regression param
+  val LR_USE_INTERCEPT = "ml.lr.use.intercept"
+  val DEFAULT_LR_USE_INTERCEPT = false
+
   // Kmeans params
   val KMEANS_CENTER_NUM = "ml.kmeans.center.num"
   val KMEANS_SAMPLE_RATIO_PERBATCH = "ml.kmeans.sample.ratio.perbath"

--- a/angel-ps/mllib/src/main/java/com/tencent/angel/ml/optimizer/sgd/GradientDescent.scala
+++ b/angel-ps/mllib/src/main/java/com/tencent/angel/ml/optimizer/sgd/GradientDescent.scala
@@ -82,7 +82,10 @@ object GradientDescent {
 
       model.increment(grad.timesBy(-1.0 * lr).asInstanceOf[M])
       intercept.map { bv =>
-        bv.increment(new DenseDoubleVector(1, Array(gradScalarSum)).timesBy(-lr))
+        val update = new DenseDoubleVector(1)
+        update.set(0, -lr * gradScalarSum)
+        update.setRowId(0)
+        bv.increment(update)
         bv
       }
       LOG.debug(s"Batch[$batch] loss = $batchLoss")

--- a/angel-ps/mllib/src/main/java/com/tencent/angel/ml/optimizer/sgd/GradientDescent.scala
+++ b/angel-ps/mllib/src/main/java/com/tencent/angel/ml/optimizer/sgd/GradientDescent.scala
@@ -31,7 +31,7 @@ object GradientDescent {
 
   def miniBatchGD[M <: TDoubleVector](trainData: DataBlock[LabeledData],
                                       model: PSModel[M],
-                                      intercept: Option[PSModel[DenseDoubleVector]],
+                                      intercept: Option[PSModel[M]],
                                       lr: Double,
                                       loss: Loss,
                                       batchSize: Int,

--- a/angel-ps/mllib/src/main/java/com/tencent/angel/ml/optimizer/sgd/GradientDescent.scala
+++ b/angel-ps/mllib/src/main/java/com/tencent/angel/ml/optimizer/sgd/GradientDescent.scala
@@ -29,11 +29,17 @@ object GradientDescent {
   private val LOG: Log = LogFactory.getLog(GradientDescent.getClass)
 
 
-  def miniBatchGD[M <: TDoubleVector](trainData: DataBlock[LabeledData], model: PSModel[M], lr:
-  Double, loss: Loss, batchSize: Int, batchNum: Int): (Double, TDoubleVector) = {
+  def miniBatchGD[M <: TDoubleVector](trainData: DataBlock[LabeledData],
+                                      model: PSModel[M],
+                                      intercept: Option[PSModel[DenseDoubleVector]],
+                                      lr: Double,
+                                      loss: Loss,
+                                      batchSize: Int,
+                                      batchNum: Int): (Double, TDoubleVector) = {
 
     //Pull model from PS Server
     val w = model.getRow(0)
+    var b: Option[Double] = intercept.map(_.getRow(0).get(0))
     var totalLoss = 0.0
 
     val taskContext = model.getTaskContext
@@ -44,16 +50,19 @@ object GradientDescent {
       grad.setRowId(0)
 
       var batchLoss: Double = 0.0
+      var gradScalarSum: Double = 0.0
 
       for (i <- 0 until batchSize) {
         val (x: TAbstractVector, y: Double) = loopingData(trainData)
-        val pre = w.dot(x)
-        val gradScalar = loss.grad(pre, y)
-        grad.plusBy(x, -1.0 * gradScalar)
+        val pre = w.dot(x) + b.getOrElse(0.0)
+        val gradScalar = -loss.grad(pre, y)    // not negative gradient
+        grad.plusBy(x, gradScalar)
         batchLoss += loss.loss(pre, y)
+        gradScalarSum += gradScalar
       }
 
       grad.timesBy(1.toDouble / batchSize.asInstanceOf[Double])
+      gradScalarSum /= batchSize
 
       if (loss.isL2Reg) {
         for (index <- 0 until grad.size) {
@@ -69,10 +78,15 @@ object GradientDescent {
 
       totalLoss += batchLoss
       w.plusBy(grad, -1.0 * lr)
+      b = b.map(bv => bv - lr * gradScalarSum)
 
       model.increment(grad.timesBy(-1.0 * lr).asInstanceOf[M])
+      intercept.map { bv =>
+        bv.increment(new DenseDoubleVector(1, Array(gradScalarSum)).timesBy(-lr))
+        bv
+      }
       LOG.debug(s"Batch[$batch] loss = $batchLoss")
-      taskContext.updateProfileCounter(batchSize, (System.currentTimeMillis() - batchStartTs).toInt);
+      taskContext.updateProfileCounter(batchSize, (System.currentTimeMillis() - batchStartTs).toInt)
     }
 
     //Push model update to PS Server

--- a/angel-ps/mllib/src/main/java/com/tencent/angel/ml/optimizer/sgd/GradientDescent.scala
+++ b/angel-ps/mllib/src/main/java/com/tencent/angel/ml/optimizer/sgd/GradientDescent.scala
@@ -49,8 +49,8 @@ object GradientDescent {
       val grad = new DenseDoubleVector(w.getDimension)
       grad.setRowId(0)
 
-      val update = new DenseDoubleVector(1)
-      update.setRowId(0)
+      val bUpdate = new DenseDoubleVector(1)
+      bUpdate.setRowId(0)
 
       var batchLoss: Double = 0.0
       var gradScalarSum: Double = 0.0
@@ -85,8 +85,8 @@ object GradientDescent {
 
       model.increment(grad.timesBy(-1.0 * lr).asInstanceOf[M])
       intercept.map { bv =>
-        update.set(0, -lr * gradScalarSum)
-        bv.increment(update)
+        bUpdate.set(0, -lr * gradScalarSum)
+        bv.increment(bUpdate)
         bv
       }
       LOG.debug(s"Batch[$batch] loss = $batchLoss")

--- a/angel-ps/mllib/src/main/java/com/tencent/angel/ml/optimizer/sgd/GradientDescent.scala
+++ b/angel-ps/mllib/src/main/java/com/tencent/angel/ml/optimizer/sgd/GradientDescent.scala
@@ -49,6 +49,9 @@ object GradientDescent {
       val grad = new DenseDoubleVector(w.getDimension)
       grad.setRowId(0)
 
+      val update = new DenseDoubleVector(1)
+      update.setRowId(0)
+
       var batchLoss: Double = 0.0
       var gradScalarSum: Double = 0.0
 
@@ -82,9 +85,7 @@ object GradientDescent {
 
       model.increment(grad.timesBy(-1.0 * lr).asInstanceOf[M])
       intercept.map { bv =>
-        val update = new DenseDoubleVector(1)
         update.set(0, -lr * gradScalarSum)
-        update.setRowId(0)
         bv.increment(update)
         bv
       }

--- a/angel-ps/mllib/src/main/java/com/tencent/angel/ml/optimizer/sgd/GradientDescent.scala
+++ b/angel-ps/mllib/src/main/java/com/tencent/angel/ml/optimizer/sgd/GradientDescent.scala
@@ -92,6 +92,7 @@ object GradientDescent {
     //Push model update to PS Server
     totalLoss += loss.getReg(w)
     model.clock.get
+    intercept.map(_.clock.get)
 
     (totalLoss, w)
   }

--- a/angel-ps/mllib/src/main/java/com/tencent/angel/ml/regression/linear/LinearRegLeaner.scala
+++ b/angel-ps/mllib/src/main/java/com/tencent/angel/ml/regression/linear/LinearRegLeaner.scala
@@ -63,8 +63,8 @@ class LinearRegLeaner(override val ctx: TaskContext) extends MLLearner(ctx) {
     val learnRate = initLearnRate / Math.sqrt(1.0 + decay * epoch)
 
     // Run mini-batch gradient descent.
-    val ret = GradientDescent.miniBatchGD(trainData, model.weight, learnRate, squareLoss,
-      batchSize, batchNum)
+    val ret = GradientDescent.miniBatchGD(trainData, model.weight, None,
+                                          learnRate, squareLoss, batchSize, batchNum)
 
     val loss = ret._1
     val localW = ret._2

--- a/docs/algo/lr_on_angel.md
+++ b/docs/algo/lr_on_angel.md
@@ -50,6 +50,7 @@
   * ml.learn.rate：初始学习速率   
   * ml.learn.decay：学习速率衰减系数   
   * ml.reg.l2：L2惩罚项系数   
+  * ml.lr.use.intercept：使用截距
 
 * 输入输出参数
   * angel.train.data.path：输入数据路径   


### PR DESCRIPTION
Hi, the PR is aimed at adding intercept for logistic regression #142 .

The work is not done yet (mostly finished in fact), but feedback is necessary for me to determine whether to go further or not. Hence, the PR is opened.


### Mathematical Derivation

Given:
+  linear model: f(x) = w^T x + b
+  loss function: L(y, f(x))

the derivative of b is: \frac{dL}{df}


### Implementation

The PR is inspired by:
+ spark: [LogisticRegression.scala](https://github.com/apache/spark/blob/cb8d5cc90ff8d3c991ff33da41b136ab7634f71b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala#L1699)
+ sklearn: [logistic.py](https://github.com/scikit-learn/scikit-learn/blob/924a4661ee3e342686b89eb47c12a6e660585376/sklearn/linear_model/logistic.py#L126)


### How to test

+ [x] code review by expert.
+ [x] Perhaps some tests are needed, however, more feedback is needed for me now.


