### PR TITLE
Add two deployment doc files

### DIFF
--- a/docs/deploy/local_run_en.md
+++ b/docs/deploy/local_run_en.md
@@ -6,7 +6,7 @@ Local mode is mainly used for testing and debugging. Currently, local mode suppo
 
 * Hadoop >= 2.2.0
 * Java version 1.8
-* Angel distribution package angel-<version>-bin.zip
+* Angel distribution package angel-&lt;version&gt;-bin.zip
 
 First, configure HADOOP_HOME and JAVA_HOME, and unzip Angel distribution package. Angel jobs can run on local now. 
 

--- a/docs/deploy/local_run_en.md
+++ b/docs/deploy/local_run_en.md
@@ -1,0 +1,17 @@
+# Local Mode
+
+Local mode is mainly used for testing and debugging. Currently, local mode support only one worker (allowing multiple tasks) and one PS. Configure `angel.deploy.mode` to run local mode; detailed parameter configurations can be found in [Angel System Parameters](./config_details.md)
+
+## 1. Execution Environment Requirements
+
+* Hadoop >= 2.2.0
+* Java version 1.8
+* Angel distribution package angel-<version>-bin.zip
+
+First, configure HADOOP_HOME and JAVA_HOME, and unzip Angel distribution package. Angel jobs can run on local now. 
+
+## 2. LOCAL Examples
+
+Once the distribution package is unzipped, find the `bin` directory under the root, and that's where all the submit scripts are located. An example running simple logistic regression can be found at:
+
+```./angel-example com.tencent.angel.example.SgdLRLocalExample```

--- a/docs/deploy/source_compile_en.md
+++ b/docs/deploy/source_compile_en.md
@@ -1,0 +1,30 @@
+# Angel Compilation Guide
+
+---
+
+1. **Compiling Environment Dependencies**
+    * Jdk >= 1.8
+    * Maven >= 3.0.5
+    * Protobuf >= 2.5.0 should be consistent with the protobuf version that Hadoop is built with; in current Apache Hadoop release, it is 2.5.0, so we recommend using version 2.5.0 unless you have compiled Hadoop using a different version of protobuf. 
+
+2. **Source Code Download**
+
+	```git clone https://github.com/Tencent/angel```
+
+3. **Compile**
+
+    Run the following command in the root directory of the source code:
+
+	```mvn clean package -Dmaven.test.skip=true```
+
+    After compiling, a distribution package named 'angel-<version>-bin.zip'  will be generated under `dist/target` under the root directory. 
+
+
+
+4. **Distribution Package**
+
+    Unpacking the distribution package, four subdirectories will be generated under the root directory: 
+    * bin: contains Angel submit scripts
+    * conf: contains system config files
+    * data: contains data for testing
+    * lib: contains jars for Angel and dependencies

--- a/docs/deploy/source_compile_en.md
+++ b/docs/deploy/source_compile_en.md
@@ -17,7 +17,7 @@
 
 	```mvn clean package -Dmaven.test.skip=true```
 
-    After compiling, a distribution package named 'angel-<version>-bin.zip'  will be generated under `dist/target` under the root directory. 
+    After compiling, a distribution package named 'angel-&lt;version&gt;-bin.zip'  will be generated under `dist/target` under the root directory. 
 
 
 


### PR DESCRIPTION
I have changed the distribution package's name to the format `angel-<version>-bin.zip`, since the version number could be different from 1.0.0, as used in the original doc. 