### PR TITLE
fix ps lr intercept

### DIFF
--- a/angel-ps/mllib/src/main/java/com/tencent/angel/ml/classification/lr/LRModel.scala
+++ b/angel-ps/mllib/src/main/java/com/tencent/angel/ml/classification/lr/LRModel.scala
@@ -85,7 +85,7 @@ class LRModel(conf: Configuration, _ctx: TaskContext = null) extends MLModel(con
     for (idx: Int <- 0 until dataSet.size) {
       val instance = dataSet.read
       val id = instance.getY
-      val dot = wVector.dot(instance.getX)
+      val dot = wVector.dot(instance.getX)+b
       val sig = MathUtils.sigmoid(dot)
       predict.put(new SparseLRPredictResult(id, dot, sig))
     }


### PR DESCRIPTION
It seems you forgot to add intercept in the predict of lrmodel.
```
       val instance = dataSet.read
        val id = instance.getY
 -      val dot = wVector.dot(instance.getX)
 +      val dot = wVector.dot(instance.getX)+b
        val sig = MathUtils.sigmoid(dot)
```