### PR TITLE
Add architecture_en.md and psfFunc_en.md

### DIFF
--- a/docs/design/psfFunc_en.md
+++ b/docs/design/psfFunc_en.md
@@ -1,0 +1,21 @@
+# psFunc (Parameter Server Func)
+
+Normally, a standard parameter server provides the basic **pull** and **push** functions. In practice, though, it is not as simple as using these basic functions to realize parameter requesting and updating for each specific algorithm, especially when the algorithm needs to implement some specific optimization mechanisms. 
+
+> For example, in some situations, an algorithm needs to get the maximum value of some row in the model matrix. If the PS system has only the basic pull interface, PSClient has to pull all columns of this row back from the PS and let the worker calculate the maximum --- this approach generates a lot of network communication cost that will affect the performance. If we have a customized function, on the other hand, each PSServer can calculate a number of local maximums and exchange to decide on the overall maximum, returning a single value --- this approach reduces the communication overhead drastically while keeping the computation cost at the same level.    
+
+In order to solve these problems, Angel introduces and implements psFunc, which encapsulates and abstractize the process of requesting and updating the remote model. psFunc is one type of user-defined functions (UDF) yet closely related to the PS operations (thus its name **psFunc**, abbreviated as **psf**). The overall architecture is shown below:  
+
+![](../img/angel_psFunc.png)
+
+>  With the introduction of psFunc, some concrete computations can happen on the PSServer side; in another word, PSServer will no longer merely store the model, but will actually be in charge of some model computations. A sensible design of psFunc can significantly accelerate the algorithm's execution.  
+
+
+It is worth noting that in many complex algorithm implementations, the introduction and strengthening of psFunc has greatly decreased the need of workers pulling back the entire model for overall calculations --- a successful detour to **model parallelization**. 
+
+We introduce psFunc in the following modules:
+
+* [Overall Design](psf_design.md)
+* [GetFunc](psf_get.md)
+* [UpdateFunc](psf_update.md)
+* [psFunc](psf_lib.md)

--- a/docs/design/psfFunc_en.md
+++ b/docs/design/psfFunc_en.md
@@ -2,16 +2,15 @@
 
 Normally, a standard parameter server provides the basic **pull** and **push** functions. In practice, though, it is not as simple as using these basic functions to realize parameter requesting and updating for each specific algorithm, especially when the algorithm needs to implement some specific optimization mechanisms. 
 
-> For example, in some situations, an algorithm needs to get the maximum value of some row in the model matrix. If the PS system has only the basic pull interface, PSClient has to pull all columns of this row back from the PS and let the worker calculate the maximum --- this approach generates a lot of network communication cost that will affect the performance. If we have a customized function, on the other hand, each PSServer can calculate a number of local maximums and exchange to decide on the overall maximum, returning a single value --- this approach reduces the communication overhead drastically while keeping the computation cost at the same level.    
+> For example, in some situations, an algorithm needs to get the maximum value of a row in the model matrix. If the PS system has only the basic pull interface, PSClient has to pull all the columns of this row back from the PS, and the worker calculates the maximum --- this approach generates a lot of network communication cost that will affect the performance. If we have a customized function, on the other hand, each PSServer can calculate a number of local maximums and exchange these values to decide on the overall maximum, returning a single value --- this approach reduces the communication overhead drastically while keeping the computation cost at the same level.    
 
-In order to solve these problems, Angel introduces and implements psFunc, which encapsulates and abstractize the process of requesting and updating the remote model. psFunc is one type of user-defined functions (UDF) yet closely related to the PS operations (thus its name **psFunc**, abbreviated as **psf**). The overall architecture is shown below:  
+In order to solve these problems, Angel introduces and implements psFunc, which encapsulates and abstractizes the process of requesting and updating the remote model. psFunc is one type of user-defined functions (UDF) yet closely related to the PS operations (thus its name **psFunc**, abbreviated as **psf**). The overall architecture is shown below:  
 
 ![](../img/angel_psFunc.png)
 
->  With the introduction of psFunc, some concrete computations can happen on the PSServer side; in another word, PSServer will no longer merely store the model, but will actually be in charge of some model computations. A sensible design of psFunc can significantly accelerate the algorithm's execution.  
+>  With the introduction of psFunc, some concrete computations can happen on the PSServer side; in another word, PSServer will no longer merely store the model, but also actually be in charge of model computations to certain extent. A sensible design of psFunc can significantly accelerate the algorithm's execution.  
 
-
-It is worth noting that in many complex algorithm implementations, the introduction and strengthening of psFunc has greatly decreased the need of workers pulling back the entire model for overall calculations --- a successful detour to **model parallelization**. 
+It is worth noting that in many complex algorithm implementations, the introduction and strengthening of psFunc has greatly decreased the need of workers pulling back the entire model for overall calculations, resulting in a successful detour to **model parallelization**. 
 
 We introduce psFunc in the following modules:
 

--- a/docs/overview/architecture_en.md
+++ b/docs/overview/architecture_en.md
@@ -1,0 +1,36 @@
+# Angel's Architecture Design
+
+----
+
+![][1]
+
+The overall design of Angel is simple, clear-cut, easy-to-use, without excessive complications; it focuses on the machine-learning model-related characteristics and pursues the best performance of high-dimensional, complex models. Angel's architecture design consists of three modules: 
+1. **Parameter Server Layer** provides a common `Parameter Service` (PS) service, responsible for the distributed model storage, communication synchronization and coordination of computing, providing `PS Service` through PSAgent2. **Worker Layer** consists of distributed compute nodes based on Angel's model design, which automatically read and partition data, compute the model updates locally, communicate with `PS Server` through `PS Client`, and complete model training or generating predictions. One worker contains one or more tasks, where a task is a computing unit in Angel. Designed this way, the tasks are able to share many public resources that a worker has acess to3. **Model Layer** is a virtue layer that is abstract rather than physical, hosting model pull/push operations, multiple sync protocols, model partitioner, psFunc...bridging between the worker layer and the PSServer. 
+ 
+In addition to the three modules, there are two important classes that deserve attention, though not shown in the chart:
+
+1. **Client**: The Initiator of Angel Application
+
+	* Start/stop PSServer
+	* Start/stop Angel worker
+	* Load/save the model
+	* Start the specific computation
+	* Obtain application status
+
+
+2. **Master**: The Maintainer of Angel Application
+
+	* Slice and distribute data and the parameter matrix 
+	* Request computing resources for worker and PSServer from Gaia
+	* Coordinate, manage and monitor worker and PSServer
+
+With the above design, Angel's overall architecture is comparatively easy to scale up. 
+
+* **PSServer Layer**: provide flexible PS support for multiple frameworks through PS-Service
+* **Model Layer**: provide necessary functions of PS and support targeted optimization for performance
+* **Worker Layer**: satisfy needs for algorithm development and innovation based on independent API 
+
+Therefore, the distributed computing engineers can optimize the core layers, whereas the algorithm engineers and data scientists can reuse these results, focusing on the maths and implementations of models/algorithms to pursue the best performance and accuracy. 
+
+
+[1]: ../img/angel_architecture_1.png

--- a/docs/overview/architecture_en.md
+++ b/docs/overview/architecture_en.md
@@ -4,8 +4,8 @@
 
 ![][1]
 
-The overall design of Angel is simple, clear-cut, easy-to-use, without excessive complications; it focuses on the machine-learning model-related characteristics and pursues the best performance of high-dimensional, complex models. Angel's architecture design consists of three modules: 
-1. **Parameter Server Layer** provides a common `Parameter Service` (PS) service, responsible for the distributed model storage, communication synchronization and coordination of computing, providing `PS Service` through PSAgent2. **Worker Layer** consists of distributed compute nodes based on Angel's model design, which automatically read and partition data, compute the model updates locally, communicate with `PS Server` through `PS Client`, and complete model training or generating predictions. One worker contains one or more tasks, where a task is a computing unit in Angel. Designed this way, the tasks are able to share many public resources that a worker has acess to3. **Model Layer** is a virtue layer that is abstract rather than physical, hosting model pull/push operations, multiple sync protocols, model partitioner, psFunc...bridging between the worker layer and the PSServer. 
+The overall design of Angel is simple, clear-cut, easy-to-use, without excessive complications; it focuses on characteristics related to machine learning models and pursues the best performance of high-dimensional models. Angel's architecture design consists of three modules: 
+1. **Parameter Server Layer** provides a common `Parameter Server` (PS) service, responsible for distributed model storage, communication synchronization and coordination of computing, also provide `PS Service` through PSAgent.2. **Worker Layer** consists of distributed compute nodes designed based on the Angel model, which automatically read and partition data, compute the model updates locally, communicate with the `PS Server` through the `PS Client`, and complete the model training and prediction generation. One worker contains one or more tasks, where a task is a computing unit in Angel; designed this way, the tasks are able to share many public resources that a worker has access to.3. **Model Layer** is an abstract, virtue layer without physical components, which hosts functionalities such as model pull/push operations, multiple sync protocols, model partitioner, psFunc, among others; this layer bridges between the worker layer and the PS layer.
  
 In addition to the three modules, there are two important classes that deserve attention, though not shown in the chart:
 
@@ -14,23 +14,23 @@ In addition to the three modules, there are two important classes that deserve a
 	* Start/stop PSServer
 	* Start/stop Angel worker
 	* Load/save the model
-	* Start the specific computation
+	* Start the specific computating process
 	* Obtain application status
 
 
-2. **Master**: The Maintainer of Angel Application
+2. **Master**: The Guardian of Angel Application
 
-	* Slice and distribute data and the parameter matrix 
-	* Request computing resources for worker and PSServer from Gaia
-	* Coordinate, manage and monitor worker and PSServer
+	* Slice and distribute raw data and the parameter matrix 
+	* Request computing resources for worker and parameter server from Gaia
+	* Coordinate, manage and monitor worker and PSServer activities
 
 With the above design, Angel's overall architecture is comparatively easy to scale up. 
 
-* **PSServer Layer**: provide flexible PS support for multiple frameworks through PS-Service
+* **PSServer Layer**: provide flexible, multi-framework PS support through PS-Service
 * **Model Layer**: provide necessary functions of PS and support targeted optimization for performance
 * **Worker Layer**: satisfy needs for algorithm development and innovation based on independent API 
 
-Therefore, the distributed computing engineers can optimize the core layers, whereas the algorithm engineers and data scientists can reuse these results, focusing on the maths and implementations of models/algorithms to pursue the best performance and accuracy. 
+Therefore, the distributed computing engineers can focus on optimization of the core layers, whereas the algorithm engineers and data scientists can focus on the algorithm development and implementation, making full use of the platform, to pursue the best performance and accuracy. 
 
 
 [1]: ../img/angel_architecture_1.png


### PR DESCRIPTION
Please kindly review these following paragraphs in architecture_en.md

- Worker Layer consists of distributed compute nodes designed based on the Angel model, which automatically read and partition data, compute the model updates locally, communicate with the PS Server through the PS Client, and complete the model training and prediction generation. One worker contains one or more tasks, where a task is a computing unit in Angel; designed this way, the tasks are able to share many public resources that a worker has access to.
- "PSServer Layer: provide flexible, multi-framework PS support through PS-Service"

psfFunc_en.md probably needs some modifications, too. Thanks. 
