### PR TITLE
fix GetPartFunc param bug.

### DIFF
--- a/angel-ps/mllib/src/main/java/com/tencent/angel/ml/lda/Inference.scala
+++ b/angel-ps/mllib/src/main/java/com/tencent/angel/ml/lda/Inference.scala
@@ -374,7 +374,8 @@ class Trainer(ctx: TaskContext, model: LDAModel,
     val futures = new mutable.HashMap[PartitionKey, Future[PartitionGetResult]]()
     while (iter.hasNext) {
       val pkey = iter.next()
-      val param = new PartitionGetParam(model.wtMat.getMatrixId, pkey)
+      // val param = new PartitionGetParam(model.wtMat.getMatrixId, pkey)
+      val param = new PartitionGetRowsParam(model.wtMat.getMatrixId(), pkey, reqRows.get(pkey.getPartitionId))
       val future = client.get(func, param)
       futures.put(pkey, future)
     }


### PR DESCRIPTION
GetPartFunc uses PartitionGetRowsParam as param class in LDA inference.