### PR TITLE
[GBDT] reduce partition number of split result

### DIFF
--- a/angel-ps/mllib/src/main/java/com/tencent/angel/ml/GBDT/GBDTModel.scala
+++ b/angel-ps/mllib/src/main/java/com/tencent/angel/ml/GBDT/GBDTModel.scala
@@ -109,33 +109,33 @@ class GBDTModel(conf: Configuration, _ctx: TaskContext = null) extends MLModel(c
   addPSModel(ACTIVE_NODE_MAT, activeTNodes)
 
   // Matrix 5: split feature
-  val splitFeat = new PSModel[TIntVector](SPLIT_FEAT_MAT, maxTreeNum, maxTNodeNum, 1, maxTNodeNum / psNumber)
+  val splitFeat = new PSModel[TIntVector](SPLIT_FEAT_MAT, maxTreeNum, maxTNodeNum, maxTreeNum, maxTNodeNum / psNumber)
     .setRowType(MLProtos.RowType.T_INT_DENSE)
     .setOplogType("DENSE_INT")
   addPSModel(SPLIT_FEAT_MAT, splitFeat)
 
   // Matrix 6: split value
-  val splitValue = PSModel[TDoubleVector](SPLIT_VALUE_MAT, maxTreeNum, maxTNodeNum, 1, maxTNodeNum / psNumber)
+  val splitValue = PSModel[TDoubleVector](SPLIT_VALUE_MAT, maxTreeNum, maxTNodeNum, maxTreeNum, maxTNodeNum / psNumber)
     .setRowType(MLProtos.RowType.T_DOUBLE_DENSE)
     .setOplogType("DENSE_DOUBLE")
   addPSModel(SPLIT_VALUE_MAT, splitValue)
 
   // Matrix 7: split loss gain
-  val splitGain = PSModel[TDoubleVector](SPLIT_GAIN_MAT, maxTreeNum, maxTNodeNum, 1, maxTNodeNum / psNumber)
+  val splitGain = PSModel[TDoubleVector](SPLIT_GAIN_MAT, maxTreeNum, maxTNodeNum, maxTreeNum, maxTNodeNum / psNumber)
     .setRowType(MLProtos.RowType.T_DOUBLE_DENSE)
     .setOplogType("DENSE_DOUBLE")
     .setNeedSave(false)
   addPSModel(SPLIT_GAIN_MAT, splitGain)
 
   // Matrix 8: node's grad stats
-  val nodeGradStats = PSModel[TDoubleVector](NODE_GRAD_MAT, maxTreeNum, 2 * maxTNodeNum, 1, 2 * maxTNodeNum / psNumber)
+  val nodeGradStats = PSModel[TDoubleVector](NODE_GRAD_MAT, maxTreeNum, 2 * maxTNodeNum, maxTreeNum, 2 * maxTNodeNum / psNumber)
     .setRowType(MLProtos.RowType.T_DOUBLE_DENSE)
     .setOplogType("DENSE_DOUBLE")
     .setNeedSave(false)
   addPSModel(NODE_GRAD_MAT, nodeGradStats)
 
   // Matrix 9: node's predict value
-  val nodePred = PSModel[TDoubleVector](NODE_PRED_MAT, maxTreeNum, maxTNodeNum, 1, maxTNodeNum / psNumber)
+  val nodePred = PSModel[TDoubleVector](NODE_PRED_MAT, maxTreeNum, maxTNodeNum, maxTreeNum, maxTNodeNum / psNumber)
     .setRowType(MLProtos.RowType.T_DOUBLE_DENSE)
     .setOplogType("DENSE_DOUBLE")
   addPSModel(NODE_PRED_MAT, nodePred)

--- a/angel-ps/mllib/src/main/java/com/tencent/angel/ml/GBDT/psf/GBDTGradHistGetRowFunc.java
+++ b/angel-ps/mllib/src/main/java/com/tencent/angel/ml/GBDT/psf/GBDTGradHistGetRowFunc.java
@@ -61,7 +61,7 @@ public class GBDTGradHistGetRowFunc extends GetRowFunc {
     Configuration conf = PSContext.get().getConf();
     PartitionGetRowParam param = (PartitionGetRowParam) partParam;
     
-    LOG.info("For the gradient histogram of GBT, we use PS to find the optimal split");
+    LOG.debug("For the gradient histogram of GBT, we use PS to find the optimal split");
 
     int splitNum = conf.getInt(MLConf.ML_GBDT_SPLIT_NUM(),
             MLConf.DEFAULT_ML_GBDT_SPLIT_NUM());
@@ -81,7 +81,7 @@ public class GBDTGradHistGetRowFunc extends GetRowFunc {
     double rightSumGrad = rightGradStat.sumGrad;
     double rightSumHess = rightGradStat.sumHess;
 
-    LOG.info(String.format(
+    LOG.debug(String.format(
         "split of matrix[%d] part[%d] row[%d]: fid[%d], split index[%d], loss gain[%f], "
             + "left sumGrad[%f], left sum hess[%f], right sumGrad[%f], right sum hess[%f]",
         param.getMatrixId(), param.getPartKey().getPartitionId(), param.getRowIndex(), fid,
@@ -93,7 +93,7 @@ public class GBDTGradHistGetRowFunc extends GetRowFunc {
     int sendEndCol = sendStartCol + 7;
     ServerDenseDoubleRow sendRow =
         new ServerDenseDoubleRow(param.getRowIndex(), sendStartCol, sendEndCol);
-    LOG.info(String.format(
+    LOG.debug(String.format(
         "Create server row of split result: row id[%d], start col[%d], end col[%d]",
         param.getRowIndex(), sendStartCol, sendEndCol));
     sendRow.getData().put(0, fid);
@@ -135,7 +135,7 @@ public class GBDTGradHistGetRowFunc extends GetRowFunc {
       splitEntry.update(curSplitEntry);
     }
 
-    LOG.info(String.format(
+    LOG.debug(String.format(
         "psFunc: the best split after looping the histogram: fid[%d], fvalue[%f], loss gain[%f]",
         splitEntry.fid, splitEntry.fvalue, splitEntry.lossChg));
 


### PR DESCRIPTION
GBDT is slow with a great number of trees.

There are too many partitions for split results on PS.

Therefore, clock requests bring a significant cost.