### PR TITLE
修改由于配置项名称写错导致预测时报错的问题

### DIFF
--- a/angel-ps/examples/src/main/java/com/tencent/angel/example/ml/LinearRegLocalExample.java
+++ b/angel-ps/examples/src/main/java/com/tencent/angel/example/ml/LinearRegLocalExample.java
@@ -132,7 +132,7 @@ public class LinearRegLocalExample {
     String TMP_PATH = System.getProperty("java.io.tmpdir", "/tmp");
 
     // Set trainning data path
-    conf.set(AngelConf.ANGEL_TRAIN_DATA_PATH, inputPath);
+    conf.set(AngelConf.ANGEL_PREDICT_DATA_PATH, inputPath);
     // Set load model path
     conf.set(AngelConf.ANGEL_LOAD_MODEL_PATH, LOCAL_FS + TMP_PATH + "/model");
     // Set predict result path


### PR DESCRIPTION
修改由于配置项名称写错导致预测时报错的问题。原代码predict方法中，设置预测数据路径时，误将ANGEL_PREDICT_DATA_PATH写成ANGEL_TRAIN_DATA_PATH，导致运行预测时报找不到预测数据的错误