### PR TITLE
Improve PyAngel Slightly

### DIFF
--- a/angel-ps/examples/src/main/python/fm_local_example.py
+++ b/angel-ps/examples/src/main/python/fm_local_example.py
@@ -23,6 +23,7 @@ from pyangel.ml.conf import MLConf
 from pyangel.ml.client.angel_client_factory import AngelClientFactory
 from pyangel.ml.factorizationmachines.runner import FMRunner
 
+
 class FMLocalExample(oject):
 
     def __init__(self):
@@ -55,12 +56,12 @@ class FMLocalExample(oject):
         self.conf.set(AngelConf.ANGEL_INPUTFORMAT_CLASS, 'org.apache.hadoop.mapreduce.lib.input.CombineTextInputFormat')
         self.conf.set_boolean(AngelConf.ANGEL_JOB_OUTPUT_PATH_DELETEONEXIST, True)
 
-        #set angel resource parameters #worker, #task, #PS
+        # set angel resource parameters #worker, #task, #PS
         self.conf.set_int(AngelConf.ANGEL_WORKERGROUP_NUMBER, 1)
         self.conf.set_int(AngelConf.ANGEL_WORKER_TASK_NUMBER, 1)
         self.conf.set_int(AngelConf.ANGEL_PS_NUMBER, 1)
 
-        #set FM algorithm parameters #feature #epoch
+        # set FM algorithm parameters #feature #epoch
         self.conf.set(MLConf.ML_FEATURE_NUM, str(feature_num))
         self.conf.set(MLConf.ML_EPOCH_NUM, str(epoch_num))
         self.conf.set(MLConf.ML_FM_RANK, str(rank))
@@ -73,12 +74,12 @@ class FMLocalExample(oject):
     def train_on_local_cluster(self):
         self.set_conf()
         input_path = "./src/test/data/fm/food_fm_libsvm"
-        LOCAL_FS = LocalFileSystem.DEFAULT_FS
-        TMP_PATH = tempfile.gettempdir()
-        save_path = LOCAL_FS + TMP_PATH + "/model"
-        log_path = LOCAL_FS + TMP_PATH + "/LRlog"
+        local_fs = LocalFileSystem.DEFAULT_FS
+        temp_path = tempfile.gettempdir()
+        save_path = local_fs+ temp_path + "/model"
+        log_path = local_fs + temp_path + "/LRlog"
 
-        # Set trainning data path
+        # Set training data path
         self.conf.set(AngelConf.ANGEL_TRAIN_DATA_PATH, input_path)
         # Set save model path
         self.conf.set(AngelConf.ANGEL_SAVE_MODEL_PATH, save_path)
@@ -95,12 +96,12 @@ class FMLocalExample(oject):
 
     def fm_classification(self):
         input_path = "./src/test/data/fm/a9a.train"
-        LOCAL_FS = LocalFileSystem.DEFAULT_FS
-        TMP_PATH = tempfile.gettempdir()
-        save_path = LOCAL_FS + TMP_PATH + "/model"
-        log_path = LOCAL_FS + TMP_PATH + "/LRlog"
+        local_fs = LocalFileSystem.DEFAULT_FS
+        temp_path = tempfile.gettempdir()
+        save_path = local_fs + temp_path + "/model"
+        log_path = local_fs + temp_path + "/LRlog"
 
-        # Set trainning data path
+        # Set training data path
         self.conf.set(AngelConf.ANGEL_TRAIN_DATA_PATH, input_path)
         # Set save model path
         self.conf.set(AngelConf.ANGEL_SAVE_MODEL_PATH, save_path)
@@ -118,6 +119,7 @@ class FMLocalExample(oject):
 
         angel_client = AngelClientFactory.get(self.conf)
         angel_client.stop()
+
 
 example = FMLocalExample()
 example.train_on_local_cluster()

--- a/angel-ps/examples/src/main/python/gbdt_example.py
+++ b/angel-ps/examples/src/main/python/gbdt_example.py
@@ -13,10 +13,13 @@
 # either express or implied. See the License for the specific language governing permissions and
 #
 
+import tempfile
+
 from pyangel.conf import AngelConf
 from pyangel.context import Configuration
 from pyangel.ml.conf import MLConf
 from pyangel.ml.gbdt.runner import GBDTRunner
+
 
 class GBDTExample(object):
 
@@ -69,14 +72,12 @@ class GBDTExample(object):
         runner = GBDTRunner()
         runner.train(self.conf)
 
-
-
     def predict(self):
         self.set_conf()
-        # Load Model from HDFS.
-        TMP_PATH = tempfile.gettempdir()
-        self.conf["gbdt.split.feature"] = TMP_PATH + "/out/xxx"
-        self.conf["gbdt.split.value"] = TMP_PATH + "/out/xxx"
+        # Load Model from HDFS. You can replace “/out/feature” and “out/value” with your prefer path
+        tmp_path = tempfile.gettempdir()
+        self.conf["gbdt.split.feature"] = tmp_path + "/out/feature"
+        self.conf["gbdt.split.value"] = tmp_path + "/out/value"
 
         runner = GBDTRunner()
 

--- a/angel-ps/examples/src/main/python/gbdt_local_example.py
+++ b/angel-ps/examples/src/main/python/gbdt_local_example.py
@@ -19,6 +19,7 @@ from pyangel.context import Configuration
 from pyangel.ml.conf import MLConf
 from pyangel.ml.gbdt.runner import GBDTRunner
 
+
 class GBDTExample(object):
 
     def __init__(self):
@@ -32,8 +33,8 @@ class GBDTExample(object):
         # and your out_path could be: "file:///home/angel/angel_1.3.0/data/output"
         # if you need, you can delete the annotation mark before Line35,Line36,Line61,Line62, so
         # there is no need for you to pass the configs every time you submit the pyangel job.
-        #input_path = "file:///${YOUR_ANGEL_HOME}/data/exampledata/GBDTLocalExampleData/agaricus.txt.train"
-        #output_path = "file:///${YOUR_ANGEL_HOME}/data/output"
+        # input_path = "file:///${YOUR_ANGEL_HOME}/data/exampledata/GBDTLocalExampleData/agaricus.txt.train"
+        # output_path = "file:///${YOUR_ANGEL_HOME}/data/output"
         # Feature number of train data
         feature_num = 127
         # Number of nonzero features
@@ -58,8 +59,8 @@ class GBDTExample(object):
 
         # set input] = output path
         self.conf[AngelConf.ANGEL_INPUTFORMAT_CLASS] = 'org.apache.hadoop.mapreduce.lib.input.CombineTextInputFormat'
-        #self.conf[AngelConf.ANGEL_TRAIN_DATA_PATH] = input_path
-        #self.conf[AngelConf.ANGEL_SAVE_MODEL_PATH] = output_path
+        # self.conf[AngelConf.ANGEL_TRAIN_DATA_PATH] = input_path
+        # self.conf[AngelConf.ANGEL_SAVE_MODEL_PATH] = output_path
 
         # Set GBDT algorithm parameters
         self.conf[MLConf.ML_FEATURE_NUM] = str(feature_num)
@@ -76,14 +77,12 @@ class GBDTExample(object):
         runner = GBDTRunner()
         runner.train(self.conf)
 
-
-
     def predict(self):
         self.set_conf()
         # Load Model from HDFS.
-        TMP_PATH = tempfile.gettempdir()
-        self.conf["gbdt.split.feature"] = TMP_PATH + "/out/xxx"
-        self.conf["gbdt.split.value"] = TMP_PATH + "/out/xxx"
+        tmp_path = tempfile.gettempdir()
+        self.conf["gbdt.split.feature"] = tmp_path + "/out/xxx"
+        self.conf["gbdt.split.value"] = tmp_path + "/out/xxx"
 
         runner = GBDTRunner()
 

--- a/angel-ps/examples/src/main/python/k_means_local_exmple.py
+++ b/angel-ps/examples/src/main/python/k_means_local_exmple.py
@@ -23,6 +23,7 @@ from pyangel.ml.conf import MLConf
 from pyangel.ml.client.angel_client_factory import AngelClientFactory
 from pyangel.ml.clustering.k_means import KMeansRunner
 
+
 class KmeansLocalExample(object):
 
     def __init__(self):

--- a/angel-ps/examples/src/main/python/linear_reg_local_example.py
+++ b/angel-ps/examples/src/main/python/linear_reg_local_example.py
@@ -22,6 +22,7 @@ from pyangel.context import Configuration
 from pyangel.ml.conf import MLConf
 from pyangel.ml.regression.runner import LinearRegRunner
 
+
 class LinearRegLocalExample(object):
     """
     Linear Regression Example used for user test, similar to "com.tencent.angel.example.ml.LinearRegLocalExample".

--- a/angel-ps/examples/src/main/python/mf_local_example.py
+++ b/angel-ps/examples/src/main/python/mf_local_example.py
@@ -22,6 +22,7 @@ from pyangel.context import Configuration
 from pyangel.ml.conf import MLConf
 from pyangel.ml.matrixfactorization.runner import MatrixFactorizationRunner
 
+
 class MFLocalExample(object):
 
     def __init__(self):

--- a/angel-ps/examples/src/main/python/sgdlr_local_example.py
+++ b/angel-ps/examples/src/main/python/sgdlr_local_example.py
@@ -22,6 +22,7 @@ from pyangel.context import Configuration
 from pyangel.ml.conf import MLConf
 from pyangel.ml.classification.runner import LRRunner
 
+
 class SGDLRLocalExample(object):
 
     def __init__(self):
@@ -91,19 +92,17 @@ class SGDLRLocalExample(object):
         # Set actionType train
         self.conf.set(AngelConf.ANGEL_ACTION_TYPE, MLConf.ANGEL_ML_TRAIN)
 
-
         runner = LRRunner()
         runner.train(self.conf)
-
 
     def inc_train(self):
         self.set_conf()
         input_path = "../data/exampledata/LRLocalExampleData/a9a.train"
-        LOCAL_FS = LocalFileSystem.DEFAULT_FS
-        TMP_PATH = tempfile.gettempdir()
-        load_path = LOCAL_FS + TMP_PATH + "/model"
-        save_path = LOCAL_FS + TMP_PATH + "/newmodel"
-        log_path = LOCAL_FS + TMP_PATH + "/log"
+        local_fs = LocalFileSystem.DEFAULT_FS
+        temp_path = tempfile.gettempdir()
+        load_path = load_fs + temp_path + "/model"
+        save_path = local_fs + temp_path + "/newmodel"
+        log_path = local_fs + temp_path + "/log"
 
         # Set trainning data path
         self.conf.set(AngelConf.ANGEL_TRAIN_DATA_PATH, input_path)
@@ -118,7 +117,6 @@ class SGDLRLocalExample(object):
 
         runner = LRRunner()
         runner.inc_train(self.conf)
-
 
     def predict(self):
         self.set_conf()
@@ -144,6 +142,7 @@ class SGDLRLocalExample(object):
         runner = LRRunner()
 
         runner.predict(self.conf)
+
 
 example = SGDLRLocalExample()
 example.train_on_local_cluster()

--- a/docs/tutorials/pyangel_quick_start.md
+++ b/docs/tutorials/pyangel_quick_start.md
@@ -2,8 +2,9 @@
 
 ## 环境
 
+* Linux任意发行版本,CentOS，Ubuntu等均可
 * Angel >= 1.3
-* Python >= 3.6 (Angel不支持Python 2）
+* Python >= 2.7
 
 ## 编写和编译
 
@@ -30,17 +31,17 @@ PyAngel支持**交互式**和**脚本式**两种提交任务的模式，而每�
 
 - **脚本式**
 
-	- **local模式**
+  - **local模式**
 
-		```bash
-		bin/angel-local-submit --angel.pyangel.pyfile ${ANGEL_HOME}/python/examples/gbdt_local_example/py
-		```
+    ```bash
+	bin/angel-local-submit --angel.pyangel.pyfile ${ANGEL_HOME}/python/examples/gbdt_local_example/py
+	```
 
-	- **Yarn模式**
+  - **Yarn模式**
 	
-		```bash
-		bin/angel-submit --angel.pyangel.pyfile ${ANGEL_HOME}/python/examples/gbdt_example.py
-		```
+	```bash
+	bin/angel-submit --angel.pyangel.pyfile ${ANGEL_HOME}/python/examples/gbdt_example.py
+	```
 
 
 
@@ -48,53 +49,56 @@ PyAngel支持**交互式**和**脚本式**两种提交任务的模式，而每�
 
 * **Local模式提交**
 
-	```bash
-	bin/angel-local-submit --angel.pyangel.pyfile ${ANGEL_HOME}/python/examples/gbdt_local_example.py \
-			        			   --angel.train.data.path "file:///${ANGEL_HOME}/data/exampledata/GBDTLocalExampleData/agaricus.txt.train" \
-			        			   --angel.log.path "file:///${ANGEL_HOME}/data/log" \
-			        			   --angel.save.model.path "file:///${ANGEL_HOME}/data/output"
+  ```bash
+  bin/angel-local-submit \
+    --angel.pyangel.pyfile ${ANGEL_HOME}/python/examples/gbdt_local_example.py \
+			  --angel.train.data.path "file:///${ANGEL_HOME}/data/exampledata/GBDTLocalExampleData/agaricus.txt.train" \
+			  --angel.log.path "file:///${ANGEL_HOME}/data/log" \
+			  --angel.save.model.path "file:///${ANGEL_HOME}/data/output"
 	```
 
 ### Example Code
 
 * **PyAngel版本的GBDT**
+    
+可以通过运行`bin/pyangel local`命令启动PyAngel本地交互式命令行，然后在命令行中输入下面的代码，运行GBDTRunner，注意：需要将input_path中的`${YOUR_ANGERL_HOME}`修改为你自己的angel绝对安装路径    
 
+  ```Python
 
-	```Python
+   from pyangel.ml.gbdt.runner import GBDTRunner
 
-		from pyangel.ml.gbdt.runner import GBDTRunner
+	# Trainning data input path
+	input_path = "file:///${YOUR_ANGEL_HOME}/data/exampledata/GBDTLocalExampleData/agaricus.txt.train"
 
-		# Trainning data input path
-		input_path = "file:///${YOUR_ANGEL_HOME}/data/exampledata/GBDTLocalExampleData/agaricus.txt.train"
+    # Algo param
+    feature_num = 127
+    feature_nzz = 25
+    tree_num = 2
+    tree_depth = 2
+    split_num = 10
+    sample_ratio = 1.0
 
-		# Algo param
-		feature_num = 127
-		feature_nzz = 25
-		tree_num = 2
-		tree_depth = 2
-		split_num = 10
-		sample_ratio = 1.0
+    # Data format
+    data_fmt = "libsvm"
 
-		# Data format
-		data_fmt = "libsvm"
+    # Learning rate
+    learn_rate = 0.01
 
-		# Learning rate
-		learn_rate = 0.01
+    # Set GBDT training data path
+    conf[AngelConf.ANGEL_TRAIN_DATA_PATH] = input_path
+    
+    # Set GBDT algorithm parameters
+    conf[MLConf.ML_FEATURE_NUM] = str(feature_num)
+    conf[MLConf.ML_FEATURE_NNZ] = str(feature_nzz)
+    conf[MLConf.ML_GBDT_TREE_NUM] = str(tree_num)
+    conf[MLConf.ML_GBDT_TREE_DEPTH] = str(tree_depth)
+    conf[MLConf.ML_GBDT_SPLIT_NUM] = str(split_num)
+    conf[MLConf.ML_GBDT_SAMPLE_RATIO] = str(sample_ratio)
+    conf[MLConf.ML_LEARN_RATE] = str(learn_rate)
 
-		# Set GBDT training data path
-		conf[AngelConf.ANGEL_TRAIN_DATA_PATH] = input_path
-		
-		# Set GBDT algorithm parameters
-		conf[MLConf.ML_FEATURE_NUM] = str(feature_num)
-		conf[MLConf.ML_FEATURE_NNZ] = str(feature_nzz)
-		conf[MLConf.ML_GBDT_TREE_NUM] = str(tree_num)
-		conf[MLConf.ML_GBDT_TREE_DEPTH] = str(tree_depth)
-		conf[MLConf.ML_GBDT_SPLIT_NUM] = str(split_num)
-		conf[MLConf.ML_GBDT_SAMPLE_RATIO] = str(sample_ratio)
-		conf[MLConf.ML_LEARN_RATE] = str(learn_rate)
+    runner = GBDTRunner()
+    runner.train(conf)
+  ```
 
-		runner = GBDTRunner()
-		runner.train(conf)
-	```
-
-* [完整代码](../../examples/src/main/python/gbdt_example.py)
+* [完整代码](../../angel-ps/examples/src/main/python/gbdt_example.py)
+* 目前PyAngel还不支持自定义Model，Task等操作，相关功能正在开发中，如有疑问以及需求，请在Angel QQ群中联系Angel8号

--- a/spark-on-angel/core/src/main/scala/com/tencent/angel/spark/models/vector/enhanced/PushMan.scala
+++ b/spark-on-angel/core/src/main/scala/com/tencent/angel/spark/models/vector/enhanced/PushMan.scala
@@ -103,10 +103,7 @@ object PushMan {
         if (mergeCache.contains((poolId, id, mergeType))) {
           val mergeArray = mergeCache((poolId, id, mergeType))
           mergeType match {
-            case INCREMENT => {
-              println(s"PushMan Increment.")
-              vectorOps.increment(poolId, id, mergeArray)
-            }
+            case INCREMENT => vectorOps.increment(poolId, id, mergeArray)
             case MAX => vectorOps.mergeMax(poolId, id, mergeArray)
             case MIN => vectorOps.mergeMin(poolId, id, mergeArray)
           }

--- a/spark-on-angel/core/src/test/scala/com/tencent/angel/spark/models/vector/enhanced/CachedPSVectorSuite.scala
+++ b/spark-on-angel/core/src/test/scala/com/tencent/angel/spark/models/vector/enhanced/CachedPSVectorSuite.scala
@@ -62,6 +62,8 @@ class CachedPSVectorSuite extends PSFunSuite with Matchers with SharedPSContext 
       }
     }
     _psVector = PSVector.dense(dim, capacity)
+
+    println(s"PushMan size: ${PushMan.cacheSize}")
   }
 
   override def afterAll(): Unit = {


### PR DESCRIPTION
Modify the start tutorials for pyangel, make sure users could simply start a python demo by launch `bin/pyangel` and `bin/angel-submit` , some compatible changes would be pushed later to support both python2 and python3.