### PR TITLE
fix run break

### DIFF
--- a/angel-ps/conf/angel-site.xml
+++ b/angel-ps/conf/angel-site.xml
@@ -18,7 +18,7 @@
 <configuration>
   <property>
     <name>angel.job.libjars</name>
-    <value>${ANGEL_HOME}/lib/scala-reflect-2.11.8.jar,${ANGEL_HOME}/lib/memory-0.8.1.jar,${ANGEL_HOME}/lib/sketches-core-0.8.1.jar,${ANGEL_HOME}/lib/commons-pool-1.6.jar,${ANGEL_HOME}/lib/kryo-shaded-4.0.0.jar,${ANGEL_HOME}/lib/kryo-serializers-0.42.jar,${ANGEL_HOME}/lib/scala-library-2.11.8.jar,${ANGEL_HOME}/lib/angel-ps-core-${ANGEL_VERSION}.jar,${ANGEL_HOME}/lib/angel-ps-tools-${ANGEL_VERSION}.jar,${ANGEL_HOME}/lib/angel-ps-mllib-${ANGEL_VERSION}.jar,${ANGEL_HOME}/lib/angel-ps-psf-${ANGEL_VERSION}.jar,${ANGEL_HOME}/lib/angel-ps-examples-${ANGEL_VERSION}.jar,${ANGEL_HOME}/lib/fastutil-7.1.0.jar,${ANGEL_HOME}/lib/sizeof-0.3.0.jar,${ANGEL_HOME}/lib/minlog-1.3.0.jar,${ANGEL_HOME}/lib/breeze_2.11-0.12.jar</value>
+    <value>${ANGEL_HOME}/lib/scala-reflect-2.11.7.jar,${ANGEL_HOME}/lib/memory-0.8.1.jar,${ANGEL_HOME}/lib/sketches-core-0.8.1.jar,${ANGEL_HOME}/lib/commons-pool-1.6.jar,${ANGEL_HOME}/lib/kryo-shaded-4.0.0.jar,${ANGEL_HOME}/lib/kryo-serializers-0.42.jar,${ANGEL_HOME}/lib/scala-library-2.11.8.jar,${ANGEL_HOME}/lib/angel-ps-core-${ANGEL_VERSION}.jar,${ANGEL_HOME}/lib/angel-ps-tools-${ANGEL_VERSION}.jar,${ANGEL_HOME}/lib/angel-ps-mllib-${ANGEL_VERSION}.jar,${ANGEL_HOME}/lib/angel-ps-psf-${ANGEL_VERSION}.jar,${ANGEL_HOME}/lib/angel-ps-examples-${ANGEL_VERSION}.jar,${ANGEL_HOME}/lib/fastutil-7.1.0.jar,${ANGEL_HOME}/lib/sizeof-0.3.0.jar,${ANGEL_HOME}/lib/minlog-1.3.0.jar,${ANGEL_HOME}/lib/breeze_2.11-0.12.jar</value>
   </property>
   <property>
     <name>mapred.mapper.new-api</name>


### PR DESCRIPTION
## What changes were proposed in this pull request?
the commit [PR](https://github.com/Tencent/angel/commit/73531b8ff854c37bb9d408bb341e6511c03536f5) brings regression.
when I use the new build angel(1.4.0)  the error below is shown
java.io.FileNotFoundException: File file:/data/users/myname/angel-1.4.0-bin/lib/scala-reflect-2.11.8.jar does not exist

mvn  dependency:tree information is: 
2078 [INFO] ------------------------------------------------------------------------
2079 [INFO] Building angel-dist 1.4.0
2080 [INFO] ------------------------------------------------------------------------
2206 [INFO] |  +- org.scalanlp:breeze_2.11:jar:0.12:compile
2207 [INFO] |  |  +- org.scalanlp:breeze-macros_2.11:jar:0.12:compile
2208 [INFO] |  |  |  \- org.scala-lang:scala-reflect:jar:2.11.7:compile

The best solution is to use scala-reflect 2.11.8
But it fails when building mllib with obscure information.
So it is safe to degrade scala-reflect to version 2.11.7

## How was this patch tested?
manual tests