### PR TITLE
Reuse gradHist Matrix to speed up sona GBDT (a little)

### DIFF
--- a/spark-on-angel/core/src/main/scala/com/tencent/angel/spark/models/matrix/DensePSMatrix.scala
+++ b/spark-on-angel/core/src/main/scala/com/tencent/angel/spark/models/matrix/DensePSMatrix.scala
@@ -87,6 +87,20 @@ class DensePSMatrix(
     PSClient.instance().denseRowOps.increment(getRow(rowId), array)
   }
 
+  /**
+    * Fill matrix with `value`
+    */
+  def fill(value: Double): Unit = {
+    assertValid()
+    PSClient.instance().matrixOps.fill(this, value)
+  }
+
+  /**
+    * Set all matrix elements to zero
+    */
+  def zero(): Unit = {
+    fill(0.0)
+  }
 
   private def getRow(rowId: Int): DensePSVector = {
     new DensePSVector(id, rowId, columns.toInt)

--- a/spark-on-angel/core/src/main/scala/com/tencent/angel/spark/models/matrix/SparsePSMatrix.scala
+++ b/spark-on-angel/core/src/main/scala/com/tencent/angel/spark/models/matrix/SparsePSMatrix.scala
@@ -45,6 +45,15 @@ class SparsePSMatrix(
     psClient.matrixOps.increment(this, pairs)
   }
 
+  def fill(value: Double): Unit = {
+    assertValid()
+    psClient.matrixOps.fill(this, value)
+  }
+
+  def zero(): Unit = {
+    fill(0.0)
+  }
+
   private def getRow(rowId: Int): SparsePSVector = {
     new SparsePSVector(id, rowId, columns)
   }

--- a/spark-on-angel/mllib/src/main/scala/com/tencent/angel/spark/ml/gbt/GBDTLearner.scala
+++ b/spark-on-angel/mllib/src/main/scala/com/tencent/angel/spark/ml/gbt/GBDTLearner.scala
@@ -219,15 +219,19 @@ class GBDTLearner(@transient val param: GBTreeParam) extends Learner {
 
 
   private def resetHistogram(gradHist: DensePSMatrix): DensePSMatrix = {
-    if (gradHist != null) gradHist.destroy()
-    val conf = SparkSession.builder().getOrCreate().sparkContext.getConf
-    val psNum = conf.get("spark.ps.instances", "1").toInt
-    val psCore = conf.get("spark.ps.cores", "1").toInt
-    val totalCore = psNum * psCore
-    val samplesPerCore = math.ceil(param.sampledFeatNum.toDouble / totalCore).toInt
+    if (gradHist != null) {
+      gradHist.zero()
+      gradHist
+    } else {
+      val conf = SparkSession.builder().getOrCreate().sparkContext.getConf
+      val psNum = conf.get("spark.ps.instances", "1").toInt
+      val psCore = conf.get("spark.ps.cores", "1").toInt
+      val totalCore = psNum * psCore
+      val samplesPerCore = math.ceil(param.sampledFeatNum.toDouble / totalCore).toInt
 
-    DensePSMatrix(param.maxNodeNum, 2 * param.splitNum * param.sampledFeatNum,
-      param.maxNodeNum, samplesPerCore * 2 * param.splitNum)
+      DensePSMatrix(param.maxNodeNum, 2 * param.splitNum * param.sampledFeatNum,
+        param.maxNodeNum, samplesPerCore * 2 * param.splitNum)
+    }
   }
 
 


### PR DESCRIPTION
The `resetHistogram` method between each iteration of active nodes is relatively slow because of it creates a new `PSMatrix` each time. And that will run `#tree * #depth` times.

I test on a dataset with 85 features, and the max-depth is set to 6. Each call of `resetHistogram` will cost 4-6 seconds, which will cost hours for hundreds of trees.
After using the `FullFill` update function, the time of that call is reduced to only several milliseconds.