### PR TITLE
[GBDT] Bug fix & histogram subtraction

### DIFF
--- a/angel-ps/mllib/src/main/java/com/tencent/angel/ml/GBDT/algo/AfterSplitRunner.java
+++ b/angel-ps/mllib/src/main/java/com/tencent/angel/ml/GBDT/algo/AfterSplitRunner.java
@@ -120,6 +120,6 @@ public class AfterSplitRunner implements Runnable {
     }
     // 5.8. deactivate active node
     this.controller.resetActiveTNodes(nid);
-    this.controller.activeNodeStat[nid] = 0;
+    this.controller.activeNodeStat[nid].decrementAndGet();
   }
 }

--- a/angel-ps/mllib/src/main/java/com/tencent/angel/ml/GBDT/algo/GBDTController.java
+++ b/angel-ps/mllib/src/main/java/com/tencent/angel/ml/GBDT/algo/GBDTController.java
@@ -409,8 +409,7 @@ public class GBDTController {
         int nodeStart = this.nodePosStart[nid];
         int nodeEnd = this.nodePosEnd[nid];
         int batchSize = this.param.batchNum;
-        int batchNum =
-          (nodeEnd - nodeStart) / batchSize + (nodeEnd - nodeStart) % batchSize == 0 ? 0 : 1;
+        int batchNum = (nodeEnd - nodeStart + 1) / batchSize + (nodeEnd - nodeStart + 1) % batchSize == 0 ? 0 : 1;
 
         // 1.2. set thread status to batch num
         this.activeNodeStat[nid] = batchNum;
@@ -711,8 +710,8 @@ public class GBDTController {
     // 4. find the cut pos
     int curInsIdx = this.instancePos[left];
     float curValue = (float) this.trainDataStore.instances.get(curInsIdx).get(splitFeature);
-    int cutPos = (curValue >= splitValue) ? left : left + 1; // the first instance that is larger
-    // than the split value
+    int cutPos = (curValue > splitValue) ? left : left + 1; // the first instance that is larger
+                                                            // than the split value
     // 5. set the span of left child
     this.nodePosStart[2 * nid + 1] = nodePosStart;
     this.nodePosEnd[2 * nid + 1] = cutPos - 1;
@@ -808,7 +807,7 @@ public class GBDTController {
         LOG.debug(String.format("Leaf weight of node[%d]: %f", nid, weight));
         int nodePosStart = this.nodePosStart[nid];
         int nodePosEnd = this.nodePosEnd[nid];
-        for (int i = nodePosStart; i < nodePosEnd; i++) {
+        for (int i = nodePosStart; i <= nodePosEnd; i++) {
           int insIdx = this.instancePos[i];
           this.trainDataStore.preds[insIdx] += this.param.learningRate * weight;
         }

--- a/angel-ps/mllib/src/main/java/com/tencent/angel/ml/GBDT/algo/GradHistThread.java
+++ b/angel-ps/mllib/src/main/java/com/tencent/angel/ml/GBDT/algo/GradHistThread.java
@@ -16,7 +16,6 @@
  */
 package com.tencent.angel.ml.GBDT.algo;
 
-import com.tencent.angel.ml.GBDT.algo.RegTree.GradHistHelper;
 import com.tencent.angel.ml.conf.MLConf;
 import com.tencent.angel.ml.math.vector.DenseDoubleVector;
 import com.tencent.angel.ml.matrix.psf.update.enhance.CompressUpdateFunc;
@@ -24,39 +23,28 @@ import com.tencent.angel.ml.model.PSModel;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-
 public class GradHistThread implements Runnable {
 
   private static final Log LOG = LogFactory.getLog(GradHistThread.class);
 
-  private final GBDTController controller;
-  private final int nid; // tree node id
   private final PSModel model;
-  private int insStart; // inclusive
-  private int insEnd; // inclusive
+  private final int nid;
+  private final DenseDoubleVector histogram;
+  private int bytesPerItem;
 
-  public GradHistThread(GBDTController controller, int nid, PSModel model, int start, int end) {
-    this.controller = controller;
-    this.nid = nid;
+  public GradHistThread(PSModel model, int nid, DenseDoubleVector histogram, int bytesPerItem) {
     this.model = model;
-    this.insStart = start;
-    this.insEnd = end;
+    this.nid = nid;
+    this.histogram = histogram;
+    this.bytesPerItem = bytesPerItem;
   }
 
   @Override public void run() {
     LOG.debug(String.format("Run active node[%d]", this.nid));
-    // 1. name of this node's grad histogram on PS
-    String histParaName = this.controller.param.gradHistNamePrefix + nid;
-    // 2. build the grad histogram of this node
-    GradHistHelper histMaker = new GradHistHelper(this.controller, this.nid);
-    DenseDoubleVector histogram = histMaker.buildHistogram(insStart, insEnd);
-    int bytesPerItem = this.controller.taskContext.getConf().
-      getInt(MLConf.ANGEL_COMPRESS_BYTES(), MLConf.DEFAULT_ANGEL_COMPRESS_BYTES());
     if (bytesPerItem < 1 || bytesPerItem > 8) {
       LOG.info("Invalid compress configuration: " + bytesPerItem + ", it should be [1,8].");
       bytesPerItem = MLConf.DEFAULT_ANGEL_COMPRESS_BYTES();
     }
-    // 3. push the histograms to PS
     try {
       if (bytesPerItem == 8) {
         this.model.increment(0, histogram);
@@ -66,11 +54,8 @@ public class GradHistThread implements Runnable {
         this.model.update(func);
       }
     } catch (Exception e) {
-      LOG.error(histParaName + " increment failed, ", e);
+      LOG.error(model.modelName() + " increment failed, ", e);
     }
-    // 4. reset thread stats to finished
-    this.controller.activeNodeStat[this.nid]--;
     LOG.debug(String.format("Active node[%d] finish", this.nid));
   }
-
 }

--- a/angel-ps/mllib/src/main/java/com/tencent/angel/ml/GBDT/algo/GradHistThread.java
+++ b/angel-ps/mllib/src/main/java/com/tencent/angel/ml/GBDT/algo/GradHistThread.java
@@ -32,8 +32,8 @@ public class GradHistThread implements Runnable {
   private final GBDTController controller;
   private final int nid; // tree node id
   private final PSModel model;
-  private int insStart;
-  private int insEnd;
+  private int insStart; // inclusive
+  private int insEnd; // inclusive
 
   public GradHistThread(GBDTController controller, int nid, PSModel model, int start, int end) {
     this.controller = controller;

--- a/angel-ps/mllib/src/main/java/com/tencent/angel/ml/GBDT/algo/HistCalculationThread.java
+++ b/angel-ps/mllib/src/main/java/com/tencent/angel/ml/GBDT/algo/HistCalculationThread.java
@@ -1,0 +1,57 @@
+/*
+ * Tencent is pleased to support the open source community by making Angel available.
+ *
+ * Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package com.tencent.angel.ml.GBDT.algo;
+
+import com.tencent.angel.ml.GBDT.algo.RegTree.GradHistHelper;
+import com.tencent.angel.ml.math.vector.DenseDoubleVector;
+import com.tencent.angel.ml.model.PSModel;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.util.concurrent.Callable;
+
+public class HistCalculationThread implements Callable<DenseDoubleVector> {
+
+  private static final Log LOG = LogFactory.getLog(HistCalculationThread.class);
+
+  private final GBDTController controller;
+  private final int nid;
+  private final int start;
+  private final int end;
+  private final int bytesPerItem;
+
+  public HistCalculationThread(GBDTController controller, int nid, int start, int end, int bytesPerItem) {
+    this.controller = controller;
+    this.nid = nid;
+    this.start = start;
+    this.end = end;
+    this.bytesPerItem = bytesPerItem;
+  }
+
+  @Override public DenseDoubleVector call() {
+    LOG.debug(String.format("Calculate active node[%d]", this.nid));
+
+    String histParaName = controller.param.gradHistNamePrefix + nid;
+    PSModel model = controller.model.getPSModel(histParaName);
+
+    GradHistHelper histMaker = new GradHistHelper(controller, nid);
+    DenseDoubleVector histogram = histMaker.buildHistogram(start, end);
+    histMaker.pushHistogram(model, histogram, bytesPerItem);
+    LOG.debug(String.format("Active node[%d] finish", this.nid));
+    return histogram;
+  }
+}

--- a/angel-ps/mllib/src/main/java/com/tencent/angel/ml/GBDT/algo/RegTree/GradHistHelper.java
+++ b/angel-ps/mllib/src/main/java/com/tencent/angel/ml/GBDT/algo/RegTree/GradHistHelper.java
@@ -54,7 +54,7 @@ public class GradHistHelper {
 
     // 2. get the span of this node
     int nodeStart = insStart;
-    int nodeEnd = insEnd;
+    int nodeEnd = insEnd; // inclusive
     LOG.debug(String
       .format("Build histogram of node[%d]: size[%d] instance span [%d - %d]", this.nid,
         histogram.getDimension(), nodeStart, nodeEnd));
@@ -83,8 +83,8 @@ public class GradHistHelper {
         }
         // 3.4.3. find the position of feature value in a histogram
         // the search area in the sketch is [fid * #splitNum, (fid+1) * #splitNum - 1]
-        int start = fPos * splitNum;
-        int end;
+        int start = fPos * splitNum; // inclusive
+        int end; // inclusive
         if (this.controller.cateFeatNum.containsKey(fid)) {
           end = start + this.controller.cateFeatNum.get(fid) - 1;
         } else {

--- a/angel-ps/mllib/src/main/java/com/tencent/angel/ml/conf/MLConf.scala
+++ b/angel-ps/mllib/src/main/java/com/tencent/angel/ml/conf/MLConf.scala
@@ -187,6 +187,8 @@ object MLConf {
   val DEFAULT_ML_GBDT_SERVER_SPLIT = false
   val ML_GBDT_CATE_FEAT = "ml.gbdt.cate.feat"
   val DEFAULT_ML_GBDT_CATE_FEAT = "none"
+  val ML_GBDT_HISTO_SUBTRACTION = "ml.gbdt.histo.subtraction"
+  val DEFAULT_ML_GBDT_HISTO_SUBTRACTION = false
 
   // FTRL param
   val ML_FTRL_ALPHA = "ml.ftrl.alpha"


### PR DESCRIPTION
Fix several boundary bugs. Maybe the beg-end naming convention usually implies left-close-right-open boundaries?

Add histogram subtraction to speed up histogram calculation (inspired by [LightGbm](https://github.com/Microsoft/LightGBM). The basic idea is if we already know the histogram one node and its parent's, its sibling's histogram can be simply calculated by subtraction.

Re-factoring that needs more help and discussion:
- I think in GBDT, each worker group only involves one core. We can not accelerate CPU-intensive process like histogram calculation by multi-threading.
- If I'm wrong, the lock-free `activeNodeStat[]` will face severe racing condition in multi-core environment, and should be replace by `AtomicInteger` or `CountDownLatch`
- So I move the CPU-intensive procedure from `GradHistThread` into `runActiveNode`, leave the IO-intensive part, and remove sample batching. To check whether it is right, benchmark needs to be re-run (histogram subtraction should be disable).